### PR TITLE
Add image Base64 conversion tools

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -218,8 +218,8 @@ Process images entirely in the browser.
 | 138 | Image Format Converter ✅ | `image/convert` | done — Convert between PNG, JPEG, WebP, AVIF, and GIF in-browser with quality controls, JPEG background flattening, live preview, and Web Worker offloading above 500KB. |
 | 139 | Image Compressor | `image/compress` | Reduce file size with configurable quality. Real-time before/after preview. |
 | 140 | SVG Optimizer | `image/svg-optimizer` | Optimize SVG files with SVGO — remove metadata, simplify paths, collapse groups. |
-| 141 | Image → Base64 | `image/to-base64` | Convert images to Base64 data URI strings. |
-| 142 | Base64 → Image | `image/from-base64` | Decode Base64 strings back to downloadable images. |
+| 141 | Image → Base64 ✅ | `image/to-base64` | done — Convert PNG, JPEG, WebP, GIF, SVG, BMP, AVIF, and ICO images into raw Base64 or ready-to-paste data URI strings with local processing, copy/download actions, and Web Worker offload above 500KB. |
+| 142 | Base64 → Image ✅ | `image/from-base64` | done — Decode raw Base64 strings or full data URIs back into downloadable images with MIME detection, whitespace/padding normalization, live preview, fallback MIME controls, and Web Worker offload above 500KB. |
 | 143 | Image EXIF Viewer | `image/exif` | Read and display EXIF metadata — camera, GPS, date, orientation. Option to strip EXIF before download. |
 | 144 | Favicon Generator | `image/favicon` | Upload an image and generate a complete favicon set (ICO, PNG 16-512, Apple Touch, SVG). |
 | 145 | Image Color Picker | `image/color-picker` | Upload an image and pick individual pixel colors. Extract dominant color palette. |

--- a/src/lib/components/panels/image/ImageFromBase64Panel.svelte
+++ b/src/lib/components/panels/image/ImageFromBase64Panel.svelte
@@ -1,0 +1,560 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { SvelteMap } from 'svelte/reactivity';
+	import { page } from '$app/stores';
+	import type { ToolDefinition } from '$registry/types.js';
+	import WorkspaceTabs from '$components/tool/WorkspaceTabs.svelte';
+	import {
+		IMAGE_BASE64_WORKER_THRESHOLD_BYTES,
+		decodeBase64ToImage,
+		shouldUseBase64ToImageWorker,
+		type Base64ToImageOptions,
+		type Base64ToImageResult,
+		type Base64ToImageWorkerRequest,
+		type Base64ToImageWorkerResponse
+	} from '$engines/image/index.js';
+	import { t } from '$stores/language';
+	import { addToast } from '$stores/toast.store';
+	import { Copy, Download, Eraser, ImageDown, Link2, ShieldCheck, Zap } from 'lucide-svelte';
+
+	type Props = {
+		toolSlug: string;
+		workspaceTools?: ToolDefinition[];
+	};
+
+	type PendingWorkerRequest = {
+		resolve: (value: Base64ToImageResult) => void;
+		reject: (reason: Error) => void;
+	};
+
+	type StatCard = { label: string; value: string; helper: string };
+
+	type FallbackMimeOption = 'image/png' | 'image/jpeg' | 'image/webp' | 'image/gif' | 'image/avif';
+
+	const FALLBACK_MIME_TYPES: FallbackMimeOption[] = [
+		'image/png',
+		'image/jpeg',
+		'image/webp',
+		'image/gif',
+		'image/avif'
+	];
+
+	let { toolSlug, workspaceTools = [] }: Props = $props();
+
+	let inputValue = $state('');
+	let fallbackMimeType = $state<FallbackMimeOption>('image/png');
+	let result = $state<Base64ToImageResult | null>(null);
+	let isProcessing = $state(false);
+	let processedByWorker = $state(false);
+let currentErrorMessage = $state('');
+
+	let workerInstance: Worker | null = null;
+	let workerRequestId = 0;
+	let latestProcessToken = 0;
+	const pendingWorkerRequests = new SvelteMap<number, PendingWorkerRequest>();
+
+	let workerThresholdLabel = $derived(formatBytes(IMAGE_BASE64_WORKER_THRESHOLD_BYTES));
+	let inputBytes = $derived(byteSize(inputValue));
+	let inputStatus = $derived(
+		$t(
+			'ui.image_from_base64.input_status',
+			{
+				size: formatBytes(inputBytes),
+				characters: inputValue.length.toLocaleString()
+			},
+			'{size} · {characters} chars'
+		)
+	);
+	let outputStatus = $derived(
+		$t(
+			'ui.image_from_base64.output_status',
+			{
+				size: formatBytes(result?.metrics.byteLength ?? 0),
+				type: result ? formatMimeLabel(result.mimeType) : '—'
+			},
+			'{size} · {type}'
+		)
+	);
+	let isWorkerEligible = $derived(shouldUseBase64ToImageWorker(inputValue));
+	let canDownload = $derived(Boolean(result?.dataUrl));
+	let canCopyDataUrl = $derived(Boolean(result?.dataUrl));
+	let canCopyBase64 = $derived(Boolean(result?.base64));
+	let canApplySample = $derived(!isProcessing);
+	let statCards = $derived<StatCard[]>([
+		{
+			label: $t('ui.image_from_base64.stat.output_type', 'Output type'),
+			value: result ? formatMimeLabel(result.mimeType) : '—',
+			helper: $t('ui.image_from_base64.stat.output_type_helper', 'Detected or fallback MIME')
+		},
+		{
+			label: $t('ui.image_from_base64.stat.output_size', 'Output size'),
+			value: result ? formatBytes(result.metrics.byteLength) : '—',
+			helper: $t('ui.image_from_base64.stat.output_size_helper', 'Decoded binary size')
+		},
+		{
+			label: $t('ui.image_from_base64.stat.flags', 'Normalization'),
+			value: result ? summarizeFlags(result) : '—',
+			helper: $t('ui.image_from_base64.stat.flags_helper', 'Prefix, spaces, and padding')
+		}
+	]);
+
+	$effect(() => {
+		const trimmedValue = inputValue.trim();
+		if (trimmedValue.length === 0) {
+			result = null;
+			isProcessing = false;
+			processedByWorker = false;
+			currentErrorMessage = '';
+			return;
+		}
+
+		const token = ++latestProcessToken;
+		const options = readOptions();
+		isProcessing = true;
+		void processInput(token, trimmedValue, options);
+	});
+
+	onDestroy(() => {
+		releaseWorker();
+	});
+
+	async function processInput(
+		token: number,
+		value: string,
+		options: Base64ToImageOptions
+	): Promise<void> {
+		const useWorker = shouldUseBase64ToImageWorker(value);
+		try {
+			const next = useWorker ? await runWorker(value, options) : decodeBase64ToImage(value, options);
+			if (token !== latestProcessToken) return;
+			result = next;
+			processedByWorker = useWorker;
+			currentErrorMessage = '';
+		} catch (error: unknown) {
+			if (token !== latestProcessToken) return;
+			try {
+				const fallback = decodeBase64ToImage(value, options);
+				if (token !== latestProcessToken) return;
+				result = fallback;
+				processedByWorker = false;
+				currentErrorMessage = '';
+				addToast(
+					'warning',
+					$t(
+						'ui.image_from_base64.worker_failed',
+						'Worker decode failed. Falling back to main thread processing.'
+					)
+				);
+			} catch (fallbackError: unknown) {
+				if (token !== latestProcessToken) return;
+				result = null;
+				currentErrorMessage = errorMessage(fallbackError ?? error);
+			}
+		} finally {
+			if (token === latestProcessToken) isProcessing = false;
+		}
+	}
+
+	function ensureWorker(): Worker {
+		if (workerInstance) return workerInstance;
+		workerInstance = new Worker(
+			new URL('../../../workers/image-from-base64.worker.ts', import.meta.url),
+			{ type: 'module' }
+		);
+		workerInstance.onmessage = handleWorkerMessage;
+		workerInstance.onerror = handleWorkerError;
+		return workerInstance;
+	}
+
+	function releaseWorker(): void {
+		if (workerInstance) {
+			workerInstance.terminate();
+			workerInstance = null;
+		}
+		for (const pending of pendingWorkerRequests.values()) {
+			pending.reject(new Error('Worker terminated'));
+		}
+		pendingWorkerRequests.clear();
+	}
+
+	function handleWorkerMessage(event: MessageEvent<Base64ToImageWorkerResponse>): void {
+		const message = event.data;
+		const pending = pendingWorkerRequests.get(message.id);
+		if (!pending) return;
+		pendingWorkerRequests.delete(message.id);
+		if (message.error) {
+			pending.reject(new Error(message.error));
+			return;
+		}
+		if (!message.result) {
+			pending.reject(new Error('Worker returned no result'));
+			return;
+		}
+		pending.resolve(message.result);
+	}
+
+	function handleWorkerError(): void {
+		for (const pending of pendingWorkerRequests.values()) {
+			pending.reject(new Error('Worker runtime error'));
+		}
+		pendingWorkerRequests.clear();
+	}
+
+	function runWorker(input: string, options: Base64ToImageOptions): Promise<Base64ToImageResult> {
+		const worker = ensureWorker();
+		return new Promise<Base64ToImageResult>((resolve, reject) => {
+			const id = ++workerRequestId;
+			pendingWorkerRequests.set(id, { resolve, reject });
+			const request: Base64ToImageWorkerRequest = { id, input, options };
+			worker.postMessage(request);
+		});
+	}
+
+	function handleInput(event: Event): void {
+		const target = event.currentTarget;
+		if (!(target instanceof HTMLTextAreaElement)) return;
+		inputValue = target.value;
+	}
+
+	function handleFallbackMimeChange(event: Event): void {
+		const target = event.currentTarget;
+		if (!(target instanceof HTMLSelectElement)) return;
+		if (isFallbackMimeType(target.value)) {
+			fallbackMimeType = target.value;
+		}
+	}
+
+	function clearInput(): void {
+		inputValue = '';
+		result = null;
+		currentErrorMessage = '';
+		addToast('info', $t('ui.image_from_base64.input_cleared', 'Base64 input cleared'));
+	}
+
+	function loadSample(): void {
+		inputValue =
+			'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOTIiIGhlaWdodD0iMTkyIiB2aWV3Qm94PSIwIDAgMTkyIDE5MiI+PHJlY3Qgd2lkdGg9IjE5MiIgaGVpZ2h0PSIxOTIiIHJ4PSIyOCIgZmlsbD0iIzYzNjZGMSIvPjxwYXRoIGQ9Ik00OCA5Nmg5NiIgc3Ryb2tlPSIjRkZGIiBzdHJva2Utd2lkdGg9IjE2IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48cGF0aCBkPSJNOTYgNDh2OTYiIHN0cm9rZT0iI0ZGRiIgc3Ryb2tlLXdpZHRoPSIxNiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+PC9zdmc+';
+		addToast('success', $t('ui.image_from_base64.sample_loaded', 'Sample Base64 loaded'));
+	}
+
+	async function copyDataUrl(): Promise<void> {
+		if (!result) {
+			addToast('info', $t('ui.image_from_base64.copy_empty', 'Nothing to copy'));
+			return;
+		}
+		try {
+			await navigator.clipboard.writeText(result.dataUrl);
+			addToast('success', $t('ui.image_from_base64.copy_data_url_success', 'Data URL copied'));
+		} catch {
+			addToast('error', $t('ui.image_from_base64.copy_error', 'Copy failed'));
+		}
+	}
+
+	async function copyNormalizedBase64(): Promise<void> {
+		if (!result) {
+			addToast('info', $t('ui.image_from_base64.copy_empty', 'Nothing to copy'));
+			return;
+		}
+		try {
+			await navigator.clipboard.writeText(result.base64);
+			addToast(
+				'success',
+				$t('ui.image_from_base64.copy_base64_success', 'Normalized Base64 copied')
+			);
+		} catch {
+			addToast('error', $t('ui.image_from_base64.copy_error', 'Copy failed'));
+		}
+	}
+
+	function downloadImage(): void {
+		if (!result) {
+			addToast('info', $t('ui.image_from_base64.download_empty', 'Nothing to download'));
+			return;
+		}
+		try {
+			const link = document.createElement('a');
+			link.href = result.dataUrl;
+			link.download = result.downloadFilename;
+			document.body.append(link);
+			link.click();
+			link.remove();
+			addToast(
+				'success',
+				$t(
+					'ui.image_from_base64.download_success',
+					{ filename: result.downloadFilename },
+					'Downloaded {filename}'
+				)
+			);
+		} catch {
+			addToast('error', $t('ui.image_from_base64.download_error', 'Download failed'));
+		}
+	}
+
+	function readOptions(): Base64ToImageOptions {
+		return { fallbackMimeType };
+	}
+
+	function isFallbackMimeType(value: string): value is FallbackMimeOption {
+		return FALLBACK_MIME_TYPES.some((mimeType) => mimeType === value);
+	}
+
+	function errorMessage(error: unknown): string {
+		if (!(error instanceof Error)) {
+			return $t('ui.image_from_base64.decode_failed', 'Base64 image decode failed');
+		}
+		switch (error.message) {
+			case 'empty_base64_input':
+				return $t('ui.image_from_base64.error.empty', 'Paste a Base64 string to decode.');
+			case 'invalid_image_data_uri_mime':
+				return $t(
+					'ui.image_from_base64.error.invalid_mime',
+					'The data URI declares an unsupported image MIME type.'
+				);
+			case 'invalid_base64_characters':
+				return $t(
+					'ui.image_from_base64.error.invalid_characters',
+					'The input contains characters that are not valid Base64.'
+				);
+			case 'invalid_base64_padding':
+				return $t(
+					'ui.image_from_base64.error.invalid_padding',
+					'Padding must appear only at the end of the Base64 input.'
+				);
+			case 'invalid_base64_length':
+				return $t(
+					'ui.image_from_base64.error.invalid_length',
+					'The Base64 length is invalid and cannot be decoded.'
+				);
+			default:
+				return $t('ui.image_from_base64.decode_failed', 'Base64 image decode failed');
+		}
+	}
+
+	function summarizeFlags(value: Base64ToImageResult): string {
+		const flags: string[] = [];
+		if (value.metrics.hadDataUriPrefix) {
+			flags.push($t('ui.image_from_base64.flag.data_uri', 'Data URI'));
+		}
+		if (value.metrics.whitespaceRemoved) {
+			flags.push($t('ui.image_from_base64.flag.whitespace', 'Spaces removed'));
+		}
+		if (value.metrics.paddingAdded) {
+			flags.push($t('ui.image_from_base64.flag.padding', 'Padding fixed'));
+		}
+		if (value.metrics.usedFallbackMimeType) {
+			flags.push($t('ui.image_from_base64.flag.fallback', 'Fallback MIME'));
+		}
+		return flags.length > 0 ? flags.join(' · ') : $t('ui.image_from_base64.flag.clean', 'No fixes');
+	}
+
+	function formatMimeLabel(mimeType: string): string {
+		if (mimeType === 'image/png') return 'PNG';
+		if (mimeType === 'image/jpeg') return 'JPEG';
+		if (mimeType === 'image/webp') return 'WebP';
+		if (mimeType === 'image/gif') return 'GIF';
+		if (mimeType === 'image/avif') return 'AVIF';
+		if (mimeType === 'image/svg+xml') return 'SVG';
+		if (mimeType === 'image/bmp') return 'BMP';
+		if (mimeType === 'image/x-icon') return 'ICO';
+		return mimeType.replace('image/', '').toUpperCase();
+	}
+
+	function formatBytes(bytes: number): string {
+		if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+		const units = ['B', 'KB', 'MB', 'GB'];
+		let size = bytes;
+		let index = 0;
+		while (size >= 1024 && index < units.length - 1) {
+			size /= 1024;
+			index += 1;
+		}
+		const precision = size >= 10 || index === 0 ? 0 : 1;
+		return `${size.toFixed(precision)} ${units[index]}`;
+	}
+
+	function byteSize(value: string): number {
+		return new TextEncoder().encode(value).length;
+	}
+</script>
+
+<div class="flex h-full min-h-0 w-full flex-col">
+	{#if workspaceTools.length > 0}
+		<WorkspaceTabs
+			tools={workspaceTools}
+			activeSlug={toolSlug}
+			category="image"
+			locale={$page.params.lang || 'en'}
+		/>
+	{/if}
+
+	<div class="border-b border-[var(--border-default)] bg-[var(--bg-surface)] p-[var(--space-3)]">
+		<div class="grid grid-cols-1 gap-[var(--space-3)] xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+			<div class="flex flex-wrap items-center gap-[var(--space-2)]">
+				<button
+					type="button"
+					onclick={loadSample}
+					disabled={!canApplySample}
+					class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--border-default)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-secondary)] hover:bg-[var(--bg-surface-hover)] disabled:opacity-50"
+				>
+					<ImageDown size={14} />
+					{$t('ui.image_from_base64.sample', 'Load sample')}
+				</button>
+				<button
+					type="button"
+					onclick={clearInput}
+					class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--border-default)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-secondary)] hover:bg-[var(--bg-surface-hover)]"
+				>
+					<Eraser size={14} />
+					{$t('ui.image_from_base64.clear', 'Clear')}
+				</button>
+			</div>
+
+			<div class="flex flex-col gap-[var(--space-1)] text-[length:var(--text-xs)] text-[var(--text-tertiary)]">
+				<span>{inputStatus}</span>
+				{#if isWorkerEligible}
+					<span>
+						{$t(
+							'ui.image_from_base64.worker_active',
+							{ size: workerThresholdLabel },
+							'Large Base64 input detected (>{size}). Decoding runs in a Web Worker.'
+						)}
+					</span>
+				{/if}
+			</div>
+		</div>
+	</div>
+
+	<div class="grid h-full min-h-0 grid-cols-1 xl:grid-cols-[minmax(0,1fr)_minmax(460px,0.9fr)] xl:divide-x xl:divide-[var(--border-default)]">
+		<div class="flex min-h-0 flex-col bg-[var(--bg-base)]">
+			<div class="border-b border-[var(--border-default)] p-[var(--space-3)]">
+				<div class="grid grid-cols-1 gap-[var(--space-2)] sm:grid-cols-2">
+					<label class="flex flex-col gap-[var(--space-1)] text-[length:var(--text-xs)] text-[var(--text-secondary)]">
+						<span>{$t('ui.image_from_base64.fallback_mime', 'Fallback output type')}</span>
+						<select
+							value={fallbackMimeType}
+							onchange={handleFallbackMimeChange}
+							class="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--bg-surface)] px-[var(--space-2)] text-[length:var(--text-sm)] text-[var(--text-primary)]"
+						>
+							<option value="image/png">PNG</option>
+							<option value="image/jpeg">JPEG</option>
+							<option value="image/webp">WebP</option>
+							<option value="image/gif">GIF</option>
+							<option value="image/avif">AVIF</option>
+						</select>
+					</label>
+					<div class="flex items-start gap-[var(--space-2)] rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--bg-surface)] p-[var(--space-2)]">
+						<ShieldCheck size={16} class="mt-0.5 shrink-0 text-[var(--accent)]" />
+						<p class="text-[length:var(--text-xs)] text-[var(--text-tertiary)]">
+							{$t(
+								'ui.image_from_base64.privacy_note',
+								'Decoded image bytes stay in your browser; nothing is uploaded.'
+							)}
+						</p>
+					</div>
+				</div>
+				<div class="mt-[var(--space-2)] flex items-start gap-[var(--space-2)] rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--bg-base)] p-[var(--space-2)]">
+					<Zap size={16} class="mt-0.5 shrink-0 text-[var(--accent)]" />
+					<p class="text-[length:var(--text-xs)] text-[var(--text-tertiary)]">
+						{$t(
+							'ui.image_from_base64.performance_note',
+							{ size: workerThresholdLabel },
+							'Large Base64 strings use a Web Worker above {size}.'
+						)}
+					</p>
+				</div>
+			</div>
+
+			<textarea
+				value={inputValue}
+				oninput={handleInput}
+				class="h-full min-h-[320px] w-full resize-none border-0 bg-transparent p-[var(--space-4)] font-[family-name:var(--font-mono)] text-[length:var(--text-sm)] leading-[var(--leading-relaxed)] text-[var(--text-primary)] outline-none"
+				placeholder={$t(
+					'ui.image_from_base64.input_placeholder',
+					'Paste a Base64 string or full data URI here...'
+				)}
+				spellcheck="false"
+			></textarea>
+		</div>
+
+		<div class="flex min-h-0 flex-col bg-[var(--bg-surface)]">
+			<div class="grid grid-cols-1 gap-[var(--space-2)] border-b border-[var(--border-default)] p-[var(--space-3)] sm:grid-cols-3">
+				{#each statCards as card (card.label)}
+					<div class="rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--bg-base)] p-[var(--space-2)]">
+						<div class="text-[length:var(--text-xs)] text-[var(--text-tertiary)]">{card.label}</div>
+						<div class="mt-[var(--space-1)] text-[length:var(--text-lg)] font-[number:var(--weight-semibold)] text-[var(--text-primary)]">
+							{card.value}
+						</div>
+						<div class="mt-[var(--space-1)] text-[length:var(--text-xs)] text-[var(--text-tertiary)]">{card.helper}</div>
+					</div>
+				{/each}
+			</div>
+
+			{#if currentErrorMessage}
+				<div class="border-b border-[var(--border-default)] px-[var(--space-3)] py-[var(--space-3)]">
+					<div class="rounded-[var(--radius-md)] border border-[var(--border-danger)] bg-[var(--bg-danger-subtle)] px-[var(--space-3)] py-[var(--space-2)] text-[length:var(--text-sm)] text-[var(--text-danger)]">
+						{currentErrorMessage}
+					</div>
+				</div>
+			{/if}
+
+			<div class="flex flex-col gap-[var(--space-2)] border-b border-[var(--border-default)] p-[var(--space-3)] text-[length:var(--text-xs)] text-[var(--text-tertiary)] sm:flex-row sm:items-center sm:justify-between">
+				<div class="flex flex-col gap-[var(--space-1)]">
+					<span>{outputStatus}</span>
+					{#if processedByWorker}
+						<span>{$t('ui.image_from_base64.worker_used', 'Processed off-thread')}</span>
+					{/if}
+				</div>
+				<div class="flex flex-wrap items-center gap-[var(--space-2)]">
+					{#if isProcessing}
+						<span>{$t('ui.image_from_base64.processing', 'Decoding...')}</span>
+					{/if}
+					<button
+						type="button"
+						disabled={!canCopyBase64}
+						onclick={copyNormalizedBase64}
+						class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--border-default)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
+					>
+						<Copy size={14} />
+						{$t('ui.image_from_base64.copy_base64', 'Copy Base64')}
+					</button>
+					<button
+						type="button"
+						disabled={!canCopyDataUrl}
+						onclick={copyDataUrl}
+						class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--border-default)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
+					>
+						<Link2 size={14} />
+						{$t('ui.image_from_base64.copy_data_url', 'Copy data URL')}
+					</button>
+					<button
+						type="button"
+						disabled={!canDownload}
+						onclick={downloadImage}
+						class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--border-default)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
+					>
+						<Download size={14} />
+						{$t('ui.image_from_base64.download', 'Download')}
+					</button>
+				</div>
+			</div>
+
+			<div class="flex min-h-0 flex-1 items-center justify-center overflow-auto p-[var(--space-4)]">
+				{#if result?.dataUrl}
+					<img
+						src={result.dataUrl}
+						alt={$t('ui.image_from_base64.output_preview_alt', 'Decoded image preview')}
+						class="max-h-full max-w-full rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--bg-base)] object-contain"
+					/>
+				{:else}
+					<p class="text-[length:var(--text-sm)] text-[var(--text-tertiary)]">
+						{$t(
+							'ui.image_from_base64.output_placeholder',
+							'Decoded image preview appears here...'
+						)}
+					</p>
+				{/if}
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/panels/image/ImageToBase64Panel.svelte
+++ b/src/lib/components/panels/image/ImageToBase64Panel.svelte
@@ -1,0 +1,553 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { SvelteMap } from 'svelte/reactivity';
+	import { page } from '$app/stores';
+	import WorkspaceTabs from '$components/tool/WorkspaceTabs.svelte';
+	import {
+		IMAGE_BASE64_WORKER_THRESHOLD_BYTES,
+		encodeImageToBase64,
+		readImageFileAsArrayBuffer,
+		shouldUseImageToBase64Worker,
+		type ImageToBase64Input,
+		type ImageToBase64Result,
+		type ImageToBase64WorkerRequest,
+		type ImageToBase64WorkerResponse
+	} from '$engines/image/index.js';
+	import type { ToolDefinition } from '$registry/types.js';
+	import { t } from '$stores/language';
+	import { addToast } from '$stores/toast.store';
+	import { Copy, Download, Eraser, ImagePlus, Link2, ShieldCheck, Zap } from 'lucide-svelte';
+
+	type Props = {
+		toolSlug: string;
+		workspaceTools?: ToolDefinition[];
+	};
+
+	type PendingWorkerRequest = {
+		resolve: (value: ImageToBase64Result) => void;
+		reject: (reason: Error) => void;
+	};
+
+	type StatCard = { label: string; value: string; helper: string };
+
+	const ACCEPTED_IMAGE_TYPES =
+		'image/png,image/jpeg,image/webp,image/gif,image/bmp,image/avif,image/svg+xml,image/x-icon';
+
+	let { toolSlug, workspaceTools = [] }: Props = $props();
+
+	let inputData = $state<ImageToBase64Input | null>(null);
+	let result = $state<ImageToBase64Result | null>(null);
+	let isProcessing = $state(false);
+	let processedByWorker = $state(false);
+	let dragOver = $state(false);
+	let fileInputRef: HTMLInputElement | null = $state(null);
+	let sourcePreview = $state('');
+
+	let workerInstance: Worker | null = null;
+	let workerRequestId = 0;
+	let latestProcessToken = 0;
+	const pendingWorkerRequests = new SvelteMap<number, PendingWorkerRequest>();
+
+	let sourceName = $derived(inputData?.sourceName ?? '');
+	let sourceMimeType = $derived(result?.mimeType ?? inputData?.sourceType ?? '—');
+	let workerThresholdLabel = $derived(formatBytes(IMAGE_BASE64_WORKER_THRESHOLD_BYTES));
+	let isWorkerEligible = $derived(shouldUseImageToBase64Worker(inputData?.sourceSizeBytes ?? 0));
+	let sourceStatus = $derived(
+		$t(
+			'ui.image_to_base64.source_status',
+			{
+				size: formatBytes(inputData?.sourceSizeBytes ?? 0),
+				format: sourceMimeType
+			},
+			'{size} · {format}'
+		)
+	);
+	let outputStatus = $derived(
+		$t(
+			'ui.image_to_base64.output_status',
+			{
+				base64Chars: result ? formatNumber(result.metrics.base64Characters) : '0',
+				dataUrlChars: result ? formatNumber(result.metrics.dataUrlCharacters) : '0'
+			},
+			'{base64Chars} Base64 chars · {dataUrlChars} data URI chars'
+		)
+	);
+	let canCopyBase64 = $derived(Boolean(result?.base64));
+	let canCopyDataUri = $derived(Boolean(result?.dataUrl));
+	let canDownload = $derived(Boolean(result));
+	let statCards = $derived<StatCard[]>([
+		{
+			label: $t('ui.image_to_base64.stat.file_size', 'Image size'),
+			value: formatBytes(inputData?.sourceSizeBytes ?? 0),
+			helper: $t('ui.image_to_base64.stat.file_size_helper', 'browser-only input')
+		},
+		{
+			label: $t('ui.image_to_base64.stat.base64_length', 'Base64 length'),
+			value: result ? formatNumber(result.metrics.base64Characters) : '—',
+			helper: $t('ui.image_to_base64.stat.base64_length_helper', 'characters without prefix')
+		},
+		{
+			label: $t('ui.image_to_base64.stat.expansion', 'Payload growth'),
+			value: result ? formatSignedPercent(result.metrics.expansionPercent) : '—',
+			helper: $t('ui.image_to_base64.stat.expansion_helper', 'expected Base64 overhead')
+		}
+	]);
+
+	$effect(() => {
+		if (!inputData) {
+			result = null;
+			return;
+		}
+		const token = ++latestProcessToken;
+		isProcessing = true;
+		void processEncoding(token, inputData);
+	});
+
+	onDestroy(() => {
+		releaseWorker();
+		if (sourcePreview.startsWith('blob:')) URL.revokeObjectURL(sourcePreview);
+	});
+
+	async function processEncoding(token: number, input: ImageToBase64Input): Promise<void> {
+		const useWorker = shouldUseImageToBase64Worker(input.sourceSizeBytes);
+		try {
+			const next = useWorker ? await runWorker(input) : encodeImageToBase64(input);
+			if (token !== latestProcessToken) return;
+			result = next;
+			processedByWorker = useWorker;
+		} catch {
+			if (token !== latestProcessToken) return;
+			try {
+				const fallback = encodeImageToBase64(input);
+				if (token !== latestProcessToken) return;
+				result = fallback;
+				processedByWorker = false;
+				addToast(
+					'warning',
+					$t(
+						'ui.image_to_base64.worker_failed',
+						'Worker encoding failed. Falling back to main thread processing.'
+					)
+				);
+			} catch (error: unknown) {
+				if (token !== latestProcessToken) return;
+				result = null;
+				addToast(
+					'error',
+					translateError(
+						error,
+						$t('ui.image_to_base64.convert_failed', 'Could not convert the image to Base64')
+					)
+				);
+			}
+		} finally {
+			if (token === latestProcessToken) isProcessing = false;
+		}
+	}
+
+	function ensureWorker(): Worker {
+		if (workerInstance) return workerInstance;
+		workerInstance = new Worker(new URL('../../../workers/image-to-base64.worker.ts', import.meta.url), {
+			type: 'module'
+		});
+		workerInstance.onmessage = handleWorkerMessage;
+		workerInstance.onerror = handleWorkerError;
+		return workerInstance;
+	}
+
+	function releaseWorker(): void {
+		if (workerInstance) {
+			workerInstance.terminate();
+			workerInstance = null;
+		}
+		for (const pending of pendingWorkerRequests.values()) {
+			pending.reject(new Error('Worker terminated'));
+		}
+		pendingWorkerRequests.clear();
+	}
+
+	function handleWorkerMessage(event: MessageEvent<ImageToBase64WorkerResponse>): void {
+		const message = event.data;
+		const pending = pendingWorkerRequests.get(message.id);
+		if (!pending) return;
+		pendingWorkerRequests.delete(message.id);
+		if (message.error) {
+			pending.reject(new Error(message.error));
+			return;
+		}
+		if (!message.result) {
+			pending.reject(new Error('Worker returned no result'));
+			return;
+		}
+		pending.resolve(message.result);
+	}
+
+	function handleWorkerError(): void {
+		for (const pending of pendingWorkerRequests.values()) {
+			pending.reject(new Error('Worker runtime error'));
+		}
+		pendingWorkerRequests.clear();
+	}
+
+	function runWorker(input: ImageToBase64Input): Promise<ImageToBase64Result> {
+		const worker = ensureWorker();
+		return new Promise<ImageToBase64Result>((resolve, reject) => {
+			const id = ++workerRequestId;
+			pendingWorkerRequests.set(id, { resolve, reject });
+			const request: ImageToBase64WorkerRequest = { id, input };
+			worker.postMessage(request);
+		});
+	}
+
+	function openPicker(): void {
+		fileInputRef?.click();
+	}
+
+	function handleDragEnter(event: DragEvent): void {
+		event.preventDefault();
+		dragOver = true;
+	}
+
+	function handleDragLeave(event: DragEvent): void {
+		event.preventDefault();
+		dragOver = false;
+	}
+
+	function handleDragOver(event: DragEvent): void {
+		event.preventDefault();
+		if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy';
+	}
+
+	function handleDrop(event: DragEvent): void {
+		event.preventDefault();
+		dragOver = false;
+		const file = event.dataTransfer?.files?.[0];
+		if (file) void loadFile(file);
+	}
+
+	function handleFileInput(event: Event): void {
+		const target = event.currentTarget;
+		if (!(target instanceof HTMLInputElement)) return;
+		const file = target.files?.[0];
+		if (file) void loadFile(file);
+		target.value = '';
+	}
+
+	async function loadFile(file: File): Promise<void> {
+		if (!file.type.startsWith('image/')) {
+			addToast('error', $t('ui.image_to_base64.file_read_error', 'Could not load image file'));
+			return;
+		}
+		try {
+			if (sourcePreview.startsWith('blob:')) URL.revokeObjectURL(sourcePreview);
+			sourcePreview = URL.createObjectURL(file);
+			inputData = await readImageFileAsArrayBuffer(file);
+			addToast(
+				'success',
+				$t('ui.image_to_base64.file_loaded', { name: inputData.sourceName }, 'Loaded {name}')
+			);
+		} catch (error: unknown) {
+			addToast(
+				'error',
+				translateError(error, $t('ui.image_to_base64.file_read_error', 'Could not load image file'))
+			);
+		}
+	}
+
+	function clearInput(): void {
+		inputData = null;
+		result = null;
+		if (sourcePreview.startsWith('blob:')) URL.revokeObjectURL(sourcePreview);
+		sourcePreview = '';
+		addToast('info', $t('ui.image_to_base64.input_cleared', 'Image input cleared'));
+	}
+
+	async function copyBase64(): Promise<void> {
+		if (!result?.base64) {
+			addToast('info', $t('ui.image_to_base64.copy_empty', 'Nothing to copy'));
+			return;
+		}
+		try {
+			await navigator.clipboard.writeText(result.base64);
+			addToast('success', $t('ui.image_to_base64.copy_success', 'Output copied'));
+		} catch {
+			addToast('error', $t('ui.image_to_base64.copy_error', 'Copy failed'));
+		}
+	}
+
+	async function copyDataUri(): Promise<void> {
+		if (!result?.dataUrl) {
+			addToast('info', $t('ui.image_to_base64.copy_empty', 'Nothing to copy'));
+			return;
+		}
+		try {
+			await navigator.clipboard.writeText(result.dataUrl);
+			addToast('success', $t('ui.image_to_base64.copy_data_uri_success', 'Data URI copied'));
+		} catch {
+			addToast('error', $t('ui.image_to_base64.copy_error', 'Copy failed'));
+		}
+	}
+
+	function downloadText(content: string, filename: string): void {
+		if (!content) {
+			addToast('info', $t('ui.image_to_base64.download_empty', 'Nothing to download'));
+			return;
+		}
+		try {
+			const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement('a');
+			link.href = url;
+			link.download = filename;
+			document.body.append(link);
+			link.click();
+			link.remove();
+			URL.revokeObjectURL(url);
+			addToast(
+				'success',
+				$t('ui.image_to_base64.download_success', { filename }, 'Downloaded {filename}')
+			);
+		} catch {
+			addToast('error', $t('ui.image_to_base64.download_error', 'Download failed'));
+		}
+	}
+
+	function formatBytes(bytes: number): string {
+		if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+		const units = ['B', 'KB', 'MB', 'GB'];
+		let size = bytes;
+		let index = 0;
+		while (size >= 1024 && index < units.length - 1) {
+			size /= 1024;
+			index += 1;
+		}
+		const precision = size >= 10 || index === 0 ? 0 : 1;
+		return `${size.toFixed(precision)} ${units[index]}`;
+	}
+
+	function formatNumber(value: number): string {
+		return value.toLocaleString();
+	}
+
+	function formatSignedPercent(value: number): string {
+		if (!Number.isFinite(value)) return '—';
+		const sign = value > 0 ? '+' : '';
+		return `${sign}${value.toFixed(1)}%`;
+	}
+
+	function translateError(error: unknown, fallback: string): string {
+		const message = error instanceof Error ? error.message : '';
+		if (message === 'unsupported_image_source') {
+			return $t('ui.image_to_base64.unsupported_image', 'Unsupported image format');
+		}
+		if (message === 'empty_image_source') {
+			return $t('ui.image_to_base64.empty_image', 'The image file is empty');
+		}
+		if (message === 'could_not_read_image_file') {
+			return $t('ui.image_to_base64.file_read_error', 'Could not load image file');
+		}
+		return message || fallback;
+	}
+</script>
+
+<div class="flex h-full min-h-0 w-full flex-col">
+	{#if workspaceTools.length > 0}
+		<WorkspaceTabs
+			tools={workspaceTools}
+			activeSlug={toolSlug}
+			category="image"
+			locale={$page.params.lang || 'en'}
+		/>
+	{/if}
+
+	<div class="border-b border-[var(--border-default)] bg-[var(--bg-surface)] p-[var(--space-3)]">
+		<div class="grid grid-cols-1 gap-[var(--space-3)] xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+			<div class="flex flex-wrap items-end gap-[var(--space-2)]">
+				<button
+					type="button"
+					onclick={openPicker}
+					class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--border-default)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-secondary)] hover:bg-[var(--bg-surface-hover)]"
+				>
+					<ImagePlus size={14} />
+					{$t('ui.image_to_base64.upload', 'Upload image')}
+				</button>
+				<button
+					type="button"
+					onclick={clearInput}
+					class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--border-default)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-secondary)] hover:bg-[var(--bg-surface-hover)]"
+				>
+					<Eraser size={14} />
+					{$t('ui.image_to_base64.clear', 'Clear')}
+				</button>
+				<input
+					bind:this={fileInputRef}
+					type="file"
+					class="sr-only"
+					accept={ACCEPTED_IMAGE_TYPES}
+					onchange={handleFileInput}
+				/>
+			</div>
+			<div class="flex flex-col gap-[var(--space-1)] text-[length:var(--text-xs)] text-[var(--text-tertiary)]">
+				<span>{sourceName || $t('ui.image_to_base64.no_file', 'No image selected')}</span>
+				<span>{sourceStatus}</span>
+				{#if isWorkerEligible}
+					<span>
+						{$t(
+							'ui.image_to_base64.worker_active',
+							{ size: workerThresholdLabel },
+							'Large image detected (>{size}). Conversion runs in a Web Worker.'
+						)}
+					</span>
+				{/if}
+			</div>
+		</div>
+	</div>
+
+	<div class="grid h-full min-h-0 grid-cols-1 xl:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)] xl:divide-x xl:divide-[var(--border-default)]">
+		<div class="flex min-h-0 flex-col bg-[var(--bg-base)]">
+			<div
+				role="region"
+				aria-label={$t('ui.image_to_base64.drop_title', 'Drop image here')}
+				class="relative m-[var(--space-3)] flex min-h-[260px] flex-1 items-center justify-center overflow-hidden rounded-[var(--radius-lg)] border border-dashed border-[var(--border-default)] bg-[var(--bg-surface)] p-[var(--space-4)]"
+				class:border-[var(--accent)]={dragOver}
+				ondragenter={handleDragEnter}
+				ondragleave={handleDragLeave}
+				ondragover={handleDragOver}
+				ondrop={handleDrop}
+			>
+				{#if sourcePreview}
+					<img
+						src={sourcePreview}
+						alt={$t('ui.image_to_base64.source_preview_alt', 'Source image preview')}
+						class="max-h-full max-w-full rounded-[var(--radius-md)] object-contain"
+					/>
+				{:else}
+					<div class="max-w-md text-center text-[length:var(--text-sm)] text-[var(--text-secondary)]">
+						<p>{$t('ui.image_to_base64.drop_title', 'Drop an image here')}</p>
+						<p class="mt-[var(--space-1)] text-[length:var(--text-xs)] text-[var(--text-tertiary)]">
+							{$t(
+								'ui.image_to_base64.drop_hint',
+								'PNG, JPEG, WebP, GIF, SVG, BMP, AVIF, and ICO stay inside this browser.'
+							)}
+						</p>
+					</div>
+				{/if}
+			</div>
+		</div>
+
+		<div class="flex min-h-0 flex-col bg-[var(--bg-surface)]">
+			<div class="border-b border-[var(--border-default)] p-[var(--space-3)]">
+				<div class="grid grid-cols-1 gap-[var(--space-2)] sm:grid-cols-2">
+					<div class="flex items-start gap-[var(--space-2)] rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--bg-base)] p-[var(--space-2)]">
+						<ShieldCheck size={16} class="mt-0.5 shrink-0 text-[var(--accent)]" />
+						<p class="text-[length:var(--text-xs)] text-[var(--text-tertiary)]">
+							{$t(
+								'ui.image_to_base64.privacy_note',
+								'Encoding is local; your image never leaves the browser.'
+							)}
+						</p>
+					</div>
+					<div class="flex items-start gap-[var(--space-2)] rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--bg-base)] p-[var(--space-2)]">
+						<Zap size={16} class="mt-0.5 shrink-0 text-[var(--accent)]" />
+						<p class="text-[length:var(--text-xs)] text-[var(--text-tertiary)]">
+							{$t(
+								'ui.image_to_base64.performance_note',
+								{ size: workerThresholdLabel },
+								'Large inputs use a Web Worker above {size}.'
+							)}
+						</p>
+					</div>
+				</div>
+			</div>
+
+			<div class="grid grid-cols-1 gap-[var(--space-2)] border-b border-[var(--border-default)] p-[var(--space-3)] sm:grid-cols-3">
+				{#each statCards as card (card.label)}
+					<div class="rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--bg-base)] p-[var(--space-2)]">
+						<div class="text-[length:var(--text-xs)] text-[var(--text-tertiary)]">{card.label}</div>
+						<div class="mt-[var(--space-1)] text-[length:var(--text-lg)] font-[number:var(--weight-semibold)] text-[var(--text-primary)]">
+							{card.value}
+						</div>
+						<div class="mt-[var(--space-1)] text-[length:var(--text-xs)] text-[var(--text-tertiary)]">{card.helper}</div>
+					</div>
+				{/each}
+			</div>
+
+			<div class="flex flex-col gap-[var(--space-2)] border-b border-[var(--border-default)] p-[var(--space-3)] text-[length:var(--text-xs)] text-[var(--text-tertiary)] sm:flex-row sm:items-center sm:justify-between">
+				<div class="flex flex-col gap-[var(--space-1)]">
+					<span>{outputStatus}</span>
+					{#if processedByWorker}
+						<span>{$t('ui.image_to_base64.worker_used', 'Processed off-thread')}</span>
+					{/if}
+				</div>
+				<div class="flex flex-wrap items-center gap-[var(--space-2)]">
+					{#if isProcessing}
+						<span>{$t('ui.image_to_base64.processing', 'Encoding...')}</span>
+					{/if}
+					<button
+						type="button"
+						disabled={!canCopyBase64}
+						onclick={copyBase64}
+						class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--border-default)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
+					>
+						<Copy size={14} />
+						{$t('ui.image_to_base64.copy_base64', 'Copy Base64')}
+					</button>
+					<button
+						type="button"
+						disabled={!canCopyDataUri}
+						onclick={copyDataUri}
+						class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--border-default)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
+					>
+						<Link2 size={14} />
+						{$t('ui.image_to_base64.copy_data_uri', 'Copy data URI')}
+					</button>
+					<button
+						type="button"
+						disabled={!canDownload}
+						onclick={() => downloadText(result?.base64 ?? '', result?.downloadFilenames.base64 ?? 'image-base64.txt')}
+						class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--border-default)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
+					>
+						<Download size={14} />
+						{$t('ui.image_to_base64.download_base64', 'Download .txt')}
+					</button>
+					<button
+						type="button"
+						disabled={!canDownload}
+						onclick={() => downloadText(result?.dataUrl ?? '', result?.downloadFilenames.dataUri ?? 'image-data-uri.txt')}
+						class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--border-default)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
+					>
+						<Download size={14} />
+						{$t('ui.image_to_base64.download_data_uri', 'Download data URI')}
+					</button>
+				</div>
+			</div>
+
+			<div class="grid min-h-0 flex-1 grid-cols-1 gap-[var(--space-3)] p-[var(--space-3)]">
+				<div class="min-h-0 rounded-[var(--radius-lg)] border border-[var(--border-default)] bg-[var(--bg-base)]">
+					<div class="border-b border-[var(--border-default)] px-[var(--space-3)] py-[var(--space-2)] text-[length:var(--text-xs)] text-[var(--text-tertiary)]">
+						{$t('ui.image_to_base64.base64_output', 'Base64 output')}
+					</div>
+					<textarea
+						readonly
+						value={result?.base64 ?? ''}
+						class="h-[180px] w-full resize-none border-0 bg-transparent p-[var(--space-3)] font-[family-name:var(--font-mono)] text-[length:var(--text-sm)] leading-[var(--leading-relaxed)] text-[var(--text-primary)] outline-none"
+						placeholder={$t('ui.image_to_base64.output_placeholder', 'Encoded Base64 appears here...')}
+						spellcheck="false"
+					></textarea>
+				</div>
+				<div class="min-h-0 rounded-[var(--radius-lg)] border border-[var(--border-default)] bg-[var(--bg-base)]">
+					<div class="border-b border-[var(--border-default)] px-[var(--space-3)] py-[var(--space-2)] text-[length:var(--text-xs)] text-[var(--text-tertiary)]">
+						{$t('ui.image_to_base64.data_uri_output', 'Data URI output')}
+					</div>
+					<textarea
+						readonly
+						value={result?.dataUrl ?? ''}
+						class="h-[180px] w-full resize-none border-0 bg-transparent p-[var(--space-3)] font-[family-name:var(--font-mono)] text-[length:var(--text-sm)] leading-[var(--leading-relaxed)] text-[var(--text-primary)] outline-none"
+						placeholder={$t('ui.image_to_base64.data_uri_placeholder', 'The data URI appears here...')}
+						spellcheck="false"
+					></textarea>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/lib/engines/image/image-base64.engine.ts
+++ b/src/lib/engines/image/image-base64.engine.ts
@@ -1,0 +1,398 @@
+export type ImageToBase64Input = {
+	buffer: ArrayBuffer;
+	sourceName: string;
+	sourceType: string;
+	sourceSizeBytes: number;
+};
+
+export type ImageToBase64Metrics = {
+	sourceSizeBytes: number;
+	base64Characters: number;
+	dataUrlCharacters: number;
+	expansionPercent: number;
+};
+
+export type ImageToBase64Result = {
+	base64: string;
+	dataUrl: string;
+	mimeType: string;
+	downloadFilenames: {
+		base64: string;
+		dataUri: string;
+	};
+	metrics: ImageToBase64Metrics;
+	durationMs: number;
+};
+
+export type Base64ToImageOptions = {
+	fallbackMimeType: string;
+};
+
+export type Base64ToImageMetrics = {
+	byteLength: number;
+	base64Characters: number;
+	dataUrlCharacters: number;
+	hadDataUriPrefix: boolean;
+	usedFallbackMimeType: boolean;
+	whitespaceRemoved: boolean;
+	paddingAdded: boolean;
+};
+
+export type Base64ToImageResult = {
+	base64: string;
+	dataUrl: string;
+	mimeType: string;
+	downloadFilename: string;
+	metrics: Base64ToImageMetrics;
+	durationMs: number;
+};
+
+export type ImageToBase64WorkerRequest = {
+	id: number;
+	input: ImageToBase64Input;
+};
+
+export type ImageToBase64WorkerResponse = {
+	id: number;
+	result?: ImageToBase64Result;
+	error?: string;
+};
+
+export type Base64ToImageWorkerRequest = {
+	id: number;
+	input: string;
+	options: Base64ToImageOptions;
+};
+
+export type Base64ToImageWorkerResponse = {
+	id: number;
+	result?: Base64ToImageResult;
+	error?: string;
+};
+
+type NormalizedBase64Payload = {
+	base64: string;
+	declaredMimeType: string | null;
+	hadDataUriPrefix: boolean;
+	whitespaceRemoved: boolean;
+	paddingAdded: boolean;
+};
+
+const DATA_URL_PREFIX_PATTERN = /^data:([^;,]+)(?:;[^,]*)*;base64,([\s\S]+)$/i;
+const BASE64_BLOCK_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const MIME_EXTENSION_MAP: Record<string, string> = {
+	'image/png': 'png',
+	'image/jpeg': 'jpg',
+	'image/webp': 'webp',
+	'image/gif': 'gif',
+	'image/avif': 'avif',
+	'image/bmp': 'bmp',
+	'image/svg+xml': 'svg',
+	'image/x-icon': 'ico'
+};
+
+export const IMAGE_BASE64_WORKER_THRESHOLD_BYTES = 500 * 1024;
+
+export function shouldUseImageToBase64Worker(inputBytes: number): boolean {
+	return inputBytes > IMAGE_BASE64_WORKER_THRESHOLD_BYTES;
+}
+
+export function shouldUseBase64ToImageWorker(input: string): boolean {
+	return getByteSize(input) > IMAGE_BASE64_WORKER_THRESHOLD_BYTES;
+}
+
+export function encodeImageToBase64(input: ImageToBase64Input): ImageToBase64Result {
+	const startedAt = nowMs();
+	const mimeType = resolveImageMimeType(input.sourceType, input.sourceName);
+	if (!mimeType) {
+		throw new Error('unsupported_image_source');
+	}
+
+	const sourceSizeBytes = input.sourceSizeBytes || input.buffer.byteLength;
+	if (sourceSizeBytes === 0) {
+		throw new Error('empty_image_source');
+	}
+
+	const base64 = arrayBufferToBase64(input.buffer);
+	const dataUrl = `data:${mimeType};base64,${base64}`;
+	const baseName = getSanitizedBaseName(input.sourceName);
+
+	return {
+		base64,
+		dataUrl,
+		mimeType,
+		downloadFilenames: {
+			base64: `${baseName}-base64.txt`,
+			dataUri: `${baseName}-data-uri.txt`
+		},
+		metrics: {
+			sourceSizeBytes,
+			base64Characters: base64.length,
+			dataUrlCharacters: dataUrl.length,
+			expansionPercent: sourceSizeBytes > 0 ? (base64.length / sourceSizeBytes - 1) * 100 : 0
+		},
+		durationMs: elapsedMs(startedAt)
+	};
+}
+
+export function readImageFileAsArrayBuffer(file: File): Promise<ImageToBase64Input> {
+	return new Promise<ImageToBase64Input>((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			if (!(reader.result instanceof ArrayBuffer)) {
+				reject(new Error('could_not_read_image_file'));
+				return;
+			}
+			resolve({
+				buffer: reader.result,
+				sourceName: file.name,
+				sourceType: file.type,
+				sourceSizeBytes: file.size
+			});
+		};
+		reader.onerror = () => {
+			reject(reader.error ?? new Error('could_not_read_image_file'));
+		};
+		reader.readAsArrayBuffer(file);
+	});
+}
+
+export function decodeBase64ToImage(
+	input: string,
+	options: Partial<Base64ToImageOptions> = {}
+): Base64ToImageResult {
+	const startedAt = nowMs();
+	if (input.trim().length === 0) {
+		throw new Error('empty_base64_input');
+	}
+
+	const fallbackMimeType = normalizeImageMimeType(options.fallbackMimeType) ?? 'image/png';
+	const normalized = normalizeBase64Payload(input);
+	const binary = safeAtob(normalized.base64);
+	const detectedMimeType = detectImageMimeType(binary);
+	const declaredMimeType = normalized.declaredMimeType
+		? normalizeImageMimeType(normalized.declaredMimeType)
+		: null;
+	const mimeType = detectedMimeType ?? declaredMimeType ?? fallbackMimeType;
+	const usedFallbackMimeType = detectedMimeType === null && declaredMimeType === null;
+	const dataUrl = `data:${mimeType};base64,${normalized.base64}`;
+
+	return {
+		base64: normalized.base64,
+		dataUrl,
+		mimeType,
+		downloadFilename: `decoded-image.${extensionForMimeType(mimeType)}`,
+		metrics: {
+			byteLength: binary.length,
+			base64Characters: normalized.base64.length,
+			dataUrlCharacters: dataUrl.length,
+			hadDataUriPrefix: normalized.hadDataUriPrefix,
+			usedFallbackMimeType,
+			whitespaceRemoved: normalized.whitespaceRemoved,
+			paddingAdded: normalized.paddingAdded
+		},
+		durationMs: elapsedMs(startedAt)
+	};
+}
+
+function normalizeBase64Payload(input: string): NormalizedBase64Payload {
+	const trimmedInput = input.trim();
+	const dataUrlMatch = trimmedInput.match(DATA_URL_PREFIX_PATTERN);
+	const declaredMimeType = dataUrlMatch?.[1] ?? null;
+
+	if (declaredMimeType && !normalizeImageMimeType(declaredMimeType)) {
+		throw new Error('invalid_image_data_uri_mime');
+	}
+
+	let base64 = dataUrlMatch?.[2] ?? trimmedInput;
+	const hadDataUriPrefix = Boolean(dataUrlMatch);
+	const whitespaceRemoved = /\s/.test(base64);
+	if (whitespaceRemoved) {
+		base64 = base64.replace(/\s+/g, '');
+	}
+
+	if (base64.length === 0) {
+		throw new Error('empty_base64_input');
+	}
+
+	base64 = base64.replace(/-/g, '+').replace(/_/g, '/');
+
+	if (/[^A-Za-z0-9+/=]/.test(base64)) {
+		throw new Error('invalid_base64_characters');
+	}
+
+	const firstPaddingIndex = base64.indexOf('=');
+	if (firstPaddingIndex !== -1) {
+		const paddingSection = base64.slice(firstPaddingIndex);
+		if (/[^=]/.test(paddingSection) || paddingSection.length > 2) {
+			throw new Error('invalid_base64_padding');
+		}
+	}
+
+	const remainder = base64.length % 4;
+	if (remainder === 1) {
+		throw new Error('invalid_base64_length');
+	}
+
+	let paddingAdded = false;
+	if (remainder > 0) {
+		base64 += '='.repeat(4 - remainder);
+		paddingAdded = true;
+	}
+
+	if (!BASE64_BLOCK_PATTERN.test(base64)) {
+		throw new Error('invalid_base64_characters');
+	}
+
+	return {
+		base64,
+		declaredMimeType,
+		hadDataUriPrefix,
+		whitespaceRemoved,
+		paddingAdded
+	};
+}
+
+function resolveImageMimeType(sourceType: string, sourceName: string): string | null {
+	const normalizedSourceType = normalizeImageMimeType(sourceType);
+	if (normalizedSourceType) return normalizedSourceType;
+	return inferMimeTypeFromFilename(sourceName);
+}
+
+function normalizeImageMimeType(value: string | undefined): string | null {
+	const normalizedValue = value?.trim().toLowerCase();
+	if (!normalizedValue || !normalizedValue.startsWith('image/')) return null;
+	if (normalizedValue === 'image/jpg') return 'image/jpeg';
+	return MIME_EXTENSION_MAP[normalizedValue] ? normalizedValue : normalizedValue;
+}
+
+function inferMimeTypeFromFilename(sourceName: string): string | null {
+	const extension = sourceName.split('.').pop()?.trim().toLowerCase();
+	if (!extension) return null;
+	if (extension === 'png') return 'image/png';
+	if (extension === 'jpg' || extension === 'jpeg') return 'image/jpeg';
+	if (extension === 'webp') return 'image/webp';
+	if (extension === 'gif') return 'image/gif';
+	if (extension === 'avif') return 'image/avif';
+	if (extension === 'bmp') return 'image/bmp';
+	if (extension === 'svg') return 'image/svg+xml';
+	if (extension === 'ico') return 'image/x-icon';
+	return null;
+}
+
+function extensionForMimeType(mimeType: string): string {
+	if (MIME_EXTENSION_MAP[mimeType]) return MIME_EXTENSION_MAP[mimeType];
+	if (mimeType.startsWith('image/')) {
+		return (
+			mimeType
+				.slice('image/'.length)
+				.replace('+xml', '')
+				.replace(/[^\w-]/g, '') || 'png'
+		);
+	}
+	return 'png';
+}
+
+function getSanitizedBaseName(sourceName: string): string {
+	const trimmed = sourceName.replace(/\.[^.]+$/u, '').trim();
+	return trimmed.length > 0 ? trimmed : 'image';
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+	const bytes = new Uint8Array(buffer);
+	let binary = '';
+	const chunkSize = 0x8000;
+
+	for (let index = 0; index < bytes.length; index += chunkSize) {
+		const chunk = bytes.subarray(index, index + chunkSize);
+		binary += String.fromCharCode(...chunk);
+	}
+
+	return btoa(binary);
+}
+
+function safeAtob(value: string): string {
+	try {
+		return atob(value);
+	} catch {
+		throw new Error('invalid_base64_characters');
+	}
+}
+
+function detectImageMimeType(binary: string): string | null {
+	if (binary.length >= 8 && getByte(binary, 0) === 0x89 && sliceAscii(binary, 1, 4) === 'PNG') {
+		return 'image/png';
+	}
+
+	if (binary.length >= 3 && getByte(binary, 0) === 0xff && getByte(binary, 1) === 0xd8) {
+		return 'image/jpeg';
+	}
+
+	if (sliceAscii(binary, 0, 6) === 'GIF87a' || sliceAscii(binary, 0, 6) === 'GIF89a') {
+		return 'image/gif';
+	}
+
+	if (
+		sliceAscii(binary, 0, 4) === 'RIFF' &&
+		binary.length >= 12 &&
+		sliceAscii(binary, 8, 12) === 'WEBP'
+	) {
+		return 'image/webp';
+	}
+
+	if (
+		binary.length >= 12 &&
+		sliceAscii(binary, 4, 8) === 'ftyp' &&
+		['avif', 'avis'].includes(sliceAscii(binary, 8, 12))
+	) {
+		return 'image/avif';
+	}
+
+	if (sliceAscii(binary, 0, 2) === 'BM') {
+		return 'image/bmp';
+	}
+
+	if (
+		binary.length >= 4 &&
+		getByte(binary, 0) === 0x00 &&
+		getByte(binary, 1) === 0x00 &&
+		getByte(binary, 2) === 0x01 &&
+		getByte(binary, 3) === 0x00
+	) {
+		return 'image/x-icon';
+	}
+
+	const svgCandidate = binary
+		.slice(0, 512)
+		.trimStart()
+		.replace(/^\uFEFF/u, '');
+	if (svgCandidate.startsWith('<?xml') || svgCandidate.startsWith('<svg')) {
+		return 'image/svg+xml';
+	}
+
+	return null;
+}
+
+function sliceAscii(value: string, start: number, end: number): string {
+	return value.slice(start, end);
+}
+
+function getByte(value: string, index: number): number {
+	return value.charCodeAt(index) & 0xff;
+}
+
+function getByteSize(value: string): number {
+	return new TextEncoder().encode(value).length;
+}
+
+function nowMs(): number {
+	if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+		return performance.now();
+	}
+
+	return Date.now();
+}
+
+function elapsedMs(startedAt: number): number {
+	return Math.max(0, nowMs() - startedAt);
+}

--- a/src/lib/engines/image/index.ts
+++ b/src/lib/engines/image/index.ts
@@ -28,3 +28,23 @@ export {
 	type ImageResizerWorkerRequest,
 	type ImageResizerWorkerResponse
 } from './image.engine.js';
+
+export {
+	IMAGE_BASE64_WORKER_THRESHOLD_BYTES,
+	IMAGE_BASE64_WORKER_THRESHOLD_BYTES as IMAGE_BASE64_TEXT_WORKER_THRESHOLD_BYTES,
+	decodeBase64ToImage,
+	encodeImageToBase64,
+	readImageFileAsArrayBuffer,
+	shouldUseBase64ToImageWorker,
+	shouldUseImageToBase64Worker,
+	type Base64ToImageMetrics,
+	type Base64ToImageOptions,
+	type Base64ToImageResult,
+	type Base64ToImageWorkerRequest,
+	type Base64ToImageWorkerResponse,
+	type ImageToBase64Input,
+	type ImageToBase64Metrics,
+	type ImageToBase64Result,
+	type ImageToBase64WorkerRequest,
+	type ImageToBase64WorkerResponse
+} from './image-base64.engine.js';

--- a/src/lib/i18n/registry/de.ts
+++ b/src/lib/i18n/registry/de.ts
@@ -148,6 +148,68 @@ const registryDe: Record<string, string> = {
 		'Leichte GIF-Vorschauen aus statischen Grafiken exportieren',
 	'tool.image-format-converter.use_case.3':
 		'Bilder von Kunden vor CMS- oder API-Uploads vereinheitlichen',
+	'tool.image-to-base64.display_name': 'Bild zu Base64',
+	'tool.image-to-base64.tagline':
+		'Bilder in rohes Base64 oder sofort einsetzbare Data-URIs umwandeln',
+	'tool.image-to-base64.description':
+		'Konvertieren Sie PNG-, JPEG-, WebP-, GIF-, SVG-, BMP-, AVIF- und ICO-Bilder direkt im Browser in Base64. Kopieren Sie den reinen Base64-String oder den vollständigen Data-URI und laden Sie beide Varianten sofort herunter.',
+	'tool.image-to-base64.primary_keyword': 'bild zu base64',
+	'tool.image-to-base64.meta_title': 'Bild zu Base64 — Data-URI-Konverter | fmtly.dev',
+	'tool.image-to-base64.meta_description':
+		'Konvertieren Sie Bilder online in Base64 oder Data-URIs. Läuft komplett im Browser, bleibt privat und nutzt Web Worker für große Dateien.',
+	'tool.image-to-base64.operation': 'Bild in Base64 konvertieren',
+	'tool.image-to-base64.faq.0.question': 'Verlässt mein Bild den Browser?',
+	'tool.image-to-base64.faq.0.answer':
+		'Nein. Das Bild wird lokal im Browser gelesen und in Base64 umgewandelt. Es wird nichts auf einen Server hochgeladen.',
+	'tool.image-to-base64.faq.1.question':
+		'Was ist der Unterschied zwischen Base64 und einem Data-URI?',
+	'tool.image-to-base64.faq.1.answer':
+		'Base64 ist nur die kodierte Nutzlast. Ein Data-URI ergänzt den MIME-Typ und das Präfix data:image/...;base64,, sodass Sie den Wert direkt in HTML, CSS oder JSON einfügen können.',
+	'tool.image-to-base64.faq.2.question': 'Welche Bildformate werden unterstützt?',
+	'tool.image-to-base64.faq.2.answer':
+		'Die Oberfläche akzeptiert gängige Browser-Bildtypen wie PNG, JPEG, WebP, GIF, SVG, BMP, AVIF und ICO. Der ursprüngliche MIME-Typ wird im Data-URI beibehalten.',
+	'tool.image-to-base64.faq.3.question': 'Wie werden große Bilder verarbeitet?',
+	'tool.image-to-base64.faq.3.answer':
+		'Eingaben über 500KB werden in einem Web Worker verarbeitet, damit die Oberfläche reaktionsschnell bleibt.',
+	'tool.image-to-base64.use_case.0':
+		'Icons und kleine Assets inline in HTML, CSS oder JSON einbetten',
+	'tool.image-to-base64.use_case.1':
+		'Bild-Data-URIs für E-Mails, Komponentenbibliotheken oder Tests erzeugen',
+	'tool.image-to-base64.use_case.2':
+		'Rohes Base64 kopieren, ohne das Data-URI-Präfix manuell zu entfernen',
+	'tool.image-to-base64.use_case.3':
+		'Client-seitige Bildnutzlasten privat vorbereiten, ohne Upload-Services',
+	'tool.image-from-base64.display_name': 'Base64 zu Bild',
+	'tool.image-from-base64.tagline':
+		'Base64-Strings oder Data-URIs wieder in herunterladbare Bilder zurückwandeln',
+	'tool.image-from-base64.description':
+		'Fügen Sie rohes Base64 oder komplette Data-URIs ein, um Bilder direkt im Browser wiederherzustellen. Die Vorschau erkennt den Bildtyp, korrigiert fehlendes Padding, entfernt Leerraum und bietet sofortigen Download.',
+	'tool.image-from-base64.primary_keyword': 'base64 zu bild',
+	'tool.image-from-base64.meta_title': 'Base64 zu Bild — Data-URIs decodieren | fmtly.dev',
+	'tool.image-from-base64.meta_description':
+		'Decodieren Sie Base64 oder Data-URIs online zurück in Bilder. Erkennt MIME-Typen, korrigiert häufige Eingabefehler und läuft komplett im Browser.',
+	'tool.image-from-base64.operation': 'Base64-Bild decodieren',
+	'tool.image-from-base64.faq.0.question':
+		'Kann ich einen vollständigen Data-URI statt rohem Base64 einfügen?',
+	'tool.image-from-base64.faq.0.answer':
+		'Ja. Das Tool akzeptiert sowohl reine Base64-Strings als auch komplette data:image/...;base64,-Eingaben und normalisiert sie automatisch.',
+	'tool.image-from-base64.faq.1.question': 'Was passiert, wenn der MIME-Typ fehlt?',
+	'tool.image-from-base64.faq.1.answer':
+		'Das Tool versucht zuerst, den Bildtyp aus den decodierten Bytes zu erkennen. Falls das nicht möglich ist, wird der ausgewählte Fallback-MIME-Typ für Vorschau und Download verwendet.',
+	'tool.image-from-base64.faq.2.question': 'Werden Leerzeichen oder fehlendes Padding korrigiert?',
+	'tool.image-from-base64.faq.2.answer':
+		'Ja. Überflüssiger Leerraum wird entfernt, URL-sichere Zeichen werden normalisiert und fehlendes Padding wird ergänzt, wenn die Eingabe dadurch gültig wird.',
+	'tool.image-from-base64.faq.3.question': 'Bleibt die Base64-Eingabe privat?',
+	'tool.image-from-base64.faq.3.answer':
+		'Ja. Die gesamte Dekodierung und Vorschau läuft lokal im Browser. Nichts wird an einen Server gesendet.',
+	'tool.image-from-base64.use_case.0':
+		'Pasted Data-URIs aus HTML, CSS oder APIs wieder in echte Bilddateien umwandeln',
+	'tool.image-from-base64.use_case.1':
+		'Base64-Bildnutzlasten vor Weitergabe oder Archivierung visuell prüfen',
+	'tool.image-from-base64.use_case.2':
+		'Beschädigte Eingaben mit Leerzeichen oder fehlendem Padding wiederherstellen',
+	'tool.image-from-base64.use_case.3':
+		'In Browser-Tests oder JSON-Antworten eingebettete Bilddaten lokal herunterladen',
 	'ui.image_converter.upload': 'Bild hochladen',
 	'ui.image_converter.clear': 'Leeren',
 	'ui.image_converter.no_file': 'Kein Bild ausgewählt',
@@ -191,6 +253,104 @@ const registryDe: Record<string, string> = {
 	'ui.image_converter.copy_output': 'Data-URL kopieren',
 	'ui.image_converter.download': 'Herunterladen',
 	'ui.image_converter.output_placeholder': 'Die konvertierte Ausgabe erscheint hier...',
+	'ui.image_to_base64.upload': 'Bild hochladen',
+	'ui.image_to_base64.clear': 'Leeren',
+	'ui.image_to_base64.no_file': 'Kein Bild ausgewählt',
+	'ui.image_to_base64.source_status': '{size} · {format}',
+	'ui.image_to_base64.output_status':
+		'{base64Chars} Base64-Zeichen · {dataUrlChars} Data-URI-Zeichen',
+	'ui.image_to_base64.worker_active':
+		'Großes Bild erkannt (>{size}). Die Umwandlung läuft in einem Web Worker.',
+	'ui.image_to_base64.worker_used': 'Nebenläufig verarbeitet',
+	'ui.image_to_base64.worker_failed':
+		'Worker-Kodierung fehlgeschlagen. Verarbeitung läuft im Hauptthread weiter.',
+	'ui.image_to_base64.file_read_error': 'Bilddatei konnte nicht geladen werden',
+	'ui.image_to_base64.file_loaded': '{name} geladen',
+	'ui.image_to_base64.input_cleared': 'Bildeingabe geleert',
+	'ui.image_to_base64.copy_empty': 'Nichts zu kopieren',
+	'ui.image_to_base64.copy_success': 'Ausgabe kopiert',
+	'ui.image_to_base64.copy_data_uri_success': 'Data-URI kopiert',
+	'ui.image_to_base64.copy_error': 'Kopieren fehlgeschlagen',
+	'ui.image_to_base64.download_empty': 'Nichts zum Herunterladen',
+	'ui.image_to_base64.download_success': '{filename} heruntergeladen',
+	'ui.image_to_base64.download_error': 'Download fehlgeschlagen',
+	'ui.image_to_base64.drop_title': 'Bild hier ablegen',
+	'ui.image_to_base64.drop_hint':
+		'PNG, JPEG, WebP, GIF, SVG, BMP, AVIF und ICO bleiben in diesem Browser.',
+	'ui.image_to_base64.source_preview_alt': 'Vorschau des Quellbilds',
+	'ui.image_to_base64.privacy_note':
+		'Die Kodierung läuft lokal; Ihr Bild verlässt den Browser nie.',
+	'ui.image_to_base64.performance_note': 'Große Eingaben nutzen ab {size} einen Web Worker.',
+	'ui.image_to_base64.stat.file_size': 'Bildgröße',
+	'ui.image_to_base64.stat.file_size_helper': 'nur Browser-Eingabe',
+	'ui.image_to_base64.stat.base64_length': 'Base64-Länge',
+	'ui.image_to_base64.stat.base64_length_helper': 'Zeichen ohne Präfix',
+	'ui.image_to_base64.stat.expansion': 'Payload-Wachstum',
+	'ui.image_to_base64.stat.expansion_helper': 'erwarteter Base64-Overhead',
+	'ui.image_to_base64.processing': 'Kodieren...',
+	'ui.image_to_base64.copy_base64': 'Base64 kopieren',
+	'ui.image_to_base64.copy_data_uri': 'Data-URI kopieren',
+	'ui.image_to_base64.download_base64': '.txt herunterladen',
+	'ui.image_to_base64.download_data_uri': 'Data-URI herunterladen',
+	'ui.image_to_base64.base64_output': 'Base64-Ausgabe',
+	'ui.image_to_base64.output_placeholder': 'Das kodierte Base64 erscheint hier...',
+	'ui.image_to_base64.data_uri_output': 'Data-URI-Ausgabe',
+	'ui.image_to_base64.data_uri_placeholder': 'Der Data-URI erscheint hier...',
+	'ui.image_to_base64.unsupported_image': 'Nicht unterstütztes Bildformat',
+	'ui.image_to_base64.empty_image': 'Die Bilddatei ist leer',
+	'ui.image_to_base64.convert_failed': 'Das Bild konnte nicht in Base64 umgewandelt werden',
+	'ui.image_from_base64.input_status': '{size} · {characters} Zeichen',
+	'ui.image_from_base64.output_status': '{size} · {type}',
+	'ui.image_from_base64.worker_active':
+		'Große Base64-Eingabe erkannt (>{size}). Die Dekodierung läuft in einem Web Worker.',
+	'ui.image_from_base64.worker_used': 'Nebenläufig verarbeitet',
+	'ui.image_from_base64.worker_failed':
+		'Worker-Dekodierung fehlgeschlagen. Verarbeitung läuft im Hauptthread weiter.',
+	'ui.image_from_base64.privacy_note':
+		'Dekodierte Bilddaten bleiben in Ihrem Browser; nichts wird hochgeladen.',
+	'ui.image_from_base64.performance_note':
+		'Große Base64-Strings nutzen ab {size} einen Web Worker.',
+	'ui.image_from_base64.input_placeholder':
+		'Fügen Sie hier einen Base64-String oder vollständigen Data-URI ein...',
+	'ui.image_from_base64.output_placeholder': 'Die decodierte Bildvorschau erscheint hier...',
+	'ui.image_from_base64.stat.output_type': 'Ausgabetyp',
+	'ui.image_from_base64.stat.output_type_helper': 'Erkannter oder Fallback-MIME-Typ',
+	'ui.image_from_base64.stat.output_size': 'Ausgabegröße',
+	'ui.image_from_base64.stat.output_size_helper': 'Größe der decodierten Binärdaten',
+	'ui.image_from_base64.stat.flags': 'Normalisierung',
+	'ui.image_from_base64.stat.flags_helper': 'Präfix, Leerzeichen und Padding',
+	'ui.image_from_base64.input_cleared': 'Base64-Eingabe geleert',
+	'ui.image_from_base64.sample_loaded': 'Beispiel-Base64 geladen',
+	'ui.image_from_base64.copy_empty': 'Nichts zu kopieren',
+	'ui.image_from_base64.copy_data_url_success': 'Data-URL kopiert',
+	'ui.image_from_base64.copy_error': 'Kopieren fehlgeschlagen',
+	'ui.image_from_base64.copy_base64_success': 'Normalisiertes Base64 kopiert',
+	'ui.image_from_base64.download_empty': 'Nichts zum Herunterladen',
+	'ui.image_from_base64.download_success': '{filename} heruntergeladen',
+	'ui.image_from_base64.download_error': 'Download fehlgeschlagen',
+	'ui.image_from_base64.decode_failed': 'Base64-Bilddekodierung fehlgeschlagen',
+	'ui.image_from_base64.error.empty': 'Fügen Sie einen Base64-String zum Dekodieren ein.',
+	'ui.image_from_base64.error.invalid_mime':
+		'Der Data-URI enthält einen nicht unterstützten Bild-MIME-Typ.',
+	'ui.image_from_base64.error.invalid_characters':
+		'Die Eingabe enthält Zeichen, die nicht zu gültigem Base64 gehören.',
+	'ui.image_from_base64.error.invalid_padding':
+		'Padding-Zeichen dürfen nur am Ende der Base64-Eingabe stehen.',
+	'ui.image_from_base64.error.invalid_length':
+		'Die Base64-Länge ist ungültig und kann nicht dekodiert werden.',
+	'ui.image_from_base64.flag.data_uri': 'Data-URI',
+	'ui.image_from_base64.flag.whitespace': 'Leerzeichen entfernt',
+	'ui.image_from_base64.flag.padding': 'Padding korrigiert',
+	'ui.image_from_base64.flag.fallback': 'Fallback-MIME',
+	'ui.image_from_base64.flag.clean': 'Keine Korrekturen',
+	'ui.image_from_base64.sample': 'Beispiel laden',
+	'ui.image_from_base64.clear': 'Leeren',
+	'ui.image_from_base64.fallback_mime': 'Fallback-Ausgabetyp',
+	'ui.image_from_base64.processing': 'Dekodieren...',
+	'ui.image_from_base64.copy_base64': 'Base64 kopieren',
+	'ui.image_from_base64.copy_data_url': 'Data-URL kopieren',
+	'ui.image_from_base64.download': 'Herunterladen',
+	'ui.image_from_base64.output_preview_alt': 'Vorschau des decodierten Bildes',
 
 	// ── JSON Tools ──────────────────────────────────────────────────────────
 	'tool.json-formatter.display_name': 'JSON-Formatierer',

--- a/src/lib/i18n/registry/en.ts
+++ b/src/lib/i18n/registry/en.ts
@@ -222,6 +222,159 @@ const registryEn: Record<string, string> = {
 	'ui.image_converter.copy_output': 'Copy data URL',
 	'ui.image_converter.download': 'Download',
 	'ui.image_converter.output_placeholder': 'Converted output appears here...',
+	'tool.image-to-base64.display_name': 'Image to Base64',
+	'tool.image-to-base64.tagline': 'Turn images into raw Base64 or ready-to-paste data URIs',
+	'tool.image-to-base64.description':
+		'Convert PNG, JPEG, WebP, GIF, SVG, BMP, AVIF, and ICO images into Base64 strings or full data URIs in your browser. Copy either output, download text files, and keep large files responsive with Web Worker offloading.',
+	'tool.image-to-base64.primary_keyword': 'image to base64',
+	'tool.image-to-base64.meta_title': 'Image to Base64 — Data URI Converter | fmtly.dev',
+	'tool.image-to-base64.meta_description':
+		'Convert images to Base64 strings or data URIs in your browser. Private, instant, with copy/download actions and Web Worker support for large files.',
+	'tool.image-to-base64.operation': 'Convert image to Base64',
+	'tool.image-to-base64.faq.0.question': 'Does my image leave the browser?',
+	'tool.image-to-base64.faq.0.answer':
+		'No. The image is read, encoded, and displayed entirely in your browser. Nothing is uploaded to a server.',
+	'tool.image-to-base64.faq.1.question':
+		'What is the difference between Base64 output and a data URI?',
+	'tool.image-to-base64.faq.1.answer':
+		'Base64 output is only the encoded payload. A data URI adds the MIME prefix, such as data:image/png;base64,..., so you can paste it directly into HTML or CSS.',
+	'tool.image-to-base64.faq.2.question': 'Which image formats are supported?',
+	'tool.image-to-base64.faq.2.answer':
+		'You can load PNG, JPEG, WebP, GIF, SVG, BMP, AVIF, and ICO images. The original MIME type is preserved in the generated data URI whenever it is available.',
+	'tool.image-to-base64.faq.3.question': 'How are large images handled?',
+	'tool.image-to-base64.faq.3.answer':
+		'Images larger than 500KB are encoded in a Web Worker so the UI stays responsive during conversion.',
+	'tool.image-to-base64.use_case.0':
+		'Embed icons and small assets inline in HTML, CSS, or JSON payloads',
+	'tool.image-to-base64.use_case.1':
+		'Prepare Base64 image payloads for APIs, CMS forms, and test fixtures',
+	'tool.image-to-base64.use_case.2':
+		'Generate ready-to-paste data URIs for email templates and prototypes',
+	'tool.image-to-base64.use_case.3': 'Inspect how much a file grows before embedding it inline',
+	'tool.image-from-base64.display_name': 'Base64 to Image',
+	'tool.image-from-base64.tagline':
+		'Decode Base64 strings or data URIs back into downloadable images',
+	'tool.image-from-base64.description':
+		'Paste a raw Base64 string or full data URI to reconstruct an image in your browser. The tool normalizes whitespace and padding, detects common image formats, previews the result, and downloads the decoded file instantly.',
+	'tool.image-from-base64.primary_keyword': 'base64 to image',
+	'tool.image-from-base64.meta_title': 'Base64 to Image — Decode Data URIs | fmtly.dev',
+	'tool.image-from-base64.meta_description':
+		'Decode Base64 strings or data URIs into previewable, downloadable images in your browser. Fix whitespace, detect image types, and keep large inputs off the UI thread.',
+	'tool.image-from-base64.operation': 'Decode Base64 image',
+	'tool.image-from-base64.faq.0.question': 'Can I paste a full data URI instead of raw Base64?',
+	'tool.image-from-base64.faq.0.answer':
+		'Yes. The tool accepts both raw Base64 payloads and complete data URIs such as data:image/png;base64,....',
+	'tool.image-from-base64.faq.1.question': 'What happens if the MIME type is missing?',
+	'tool.image-from-base64.faq.1.answer':
+		'The decoder first inspects the binary signature of common image formats. If no type can be inferred, you can choose a fallback output type for the preview and download.',
+	'tool.image-from-base64.faq.2.question': 'Will it fix whitespace or missing padding?',
+	'tool.image-from-base64.faq.2.answer':
+		'Yes. The tool strips whitespace, normalizes URL-safe Base64 characters, and adds missing padding when the input can still be decoded safely.',
+	'tool.image-from-base64.faq.3.question': 'Does the Base64 input stay private?',
+	'tool.image-from-base64.faq.3.answer':
+		'Yes. Decoding runs entirely in your browser, and large inputs are moved to a Web Worker so the page remains responsive.',
+	'tool.image-from-base64.use_case.0':
+		'Recover images copied from API payloads, JSON blobs, or database exports',
+	'tool.image-from-base64.use_case.1':
+		'Preview data URIs before shipping them into HTML, CSS, or emails',
+	'tool.image-from-base64.use_case.2':
+		'Normalize copied Base64 strings that contain line breaks or missing padding',
+	'tool.image-from-base64.use_case.3':
+		'Download decoded assets quickly for manual QA or design review',
+	'ui.image_to_base64.upload': 'Upload image',
+	'ui.image_to_base64.clear': 'Clear',
+	'ui.image_to_base64.no_file': 'No image selected',
+	'ui.image_to_base64.source_status': '{size} · {format}',
+	'ui.image_to_base64.output_status': '{base64Chars} Base64 chars · {dataUrlChars} data URI chars',
+	'ui.image_to_base64.worker_active':
+		'Large image detected (>{size}). Conversion runs in a Web Worker.',
+	'ui.image_to_base64.worker_used': 'Processed off-thread',
+	'ui.image_to_base64.worker_failed':
+		'Worker encoding failed. Falling back to main thread processing.',
+	'ui.image_to_base64.file_read_error': 'Could not load image file',
+	'ui.image_to_base64.file_loaded': 'Loaded {name}',
+	'ui.image_to_base64.input_cleared': 'Image input cleared',
+	'ui.image_to_base64.copy_empty': 'Nothing to copy',
+	'ui.image_to_base64.copy_success': 'Output copied',
+	'ui.image_to_base64.copy_data_uri_success': 'Data URI copied',
+	'ui.image_to_base64.copy_error': 'Copy failed',
+	'ui.image_to_base64.download_empty': 'Nothing to download',
+	'ui.image_to_base64.download_success': 'Downloaded {filename}',
+	'ui.image_to_base64.download_error': 'Download failed',
+	'ui.image_to_base64.drop_title': 'Drop an image here',
+	'ui.image_to_base64.drop_hint':
+		'PNG, JPEG, WebP, GIF, SVG, BMP, AVIF, and ICO stay inside this browser.',
+	'ui.image_to_base64.source_preview_alt': 'Source image preview',
+	'ui.image_to_base64.privacy_note': 'Encoding is local; your image never leaves the browser.',
+	'ui.image_to_base64.performance_note': 'Large inputs use a Web Worker above {size}.',
+	'ui.image_to_base64.stat.file_size': 'Image size',
+	'ui.image_to_base64.stat.file_size_helper': 'browser-only input',
+	'ui.image_to_base64.stat.base64_length': 'Base64 length',
+	'ui.image_to_base64.stat.base64_length_helper': 'characters without prefix',
+	'ui.image_to_base64.stat.expansion': 'Payload growth',
+	'ui.image_to_base64.stat.expansion_helper': 'expected Base64 overhead',
+	'ui.image_to_base64.processing': 'Encoding...',
+	'ui.image_to_base64.copy_base64': 'Copy Base64',
+	'ui.image_to_base64.copy_data_uri': 'Copy data URI',
+	'ui.image_to_base64.download_base64': 'Download .txt',
+	'ui.image_to_base64.download_data_uri': 'Download data URI',
+	'ui.image_to_base64.base64_output': 'Base64 output',
+	'ui.image_to_base64.output_placeholder': 'Encoded Base64 appears here...',
+	'ui.image_to_base64.data_uri_output': 'Data URI output',
+	'ui.image_to_base64.data_uri_placeholder': 'The data URI appears here...',
+	'ui.image_to_base64.unsupported_image': 'Unsupported image format',
+	'ui.image_to_base64.empty_image': 'The image file is empty',
+	'ui.image_to_base64.convert_failed': 'Could not convert the image to Base64',
+	'ui.image_from_base64.input_status': '{size} · {characters} chars',
+	'ui.image_from_base64.output_status': '{size} · {type}',
+	'ui.image_from_base64.worker_active':
+		'Large Base64 input detected (>{size}). Decoding runs in a Web Worker.',
+	'ui.image_from_base64.worker_used': 'Processed off-thread',
+	'ui.image_from_base64.worker_failed':
+		'Worker decode failed. Falling back to main thread processing.',
+	'ui.image_from_base64.privacy_note':
+		'Decoded image bytes stay in your browser; nothing is uploaded.',
+	'ui.image_from_base64.performance_note': 'Large Base64 strings use a Web Worker above {size}.',
+	'ui.image_from_base64.input_placeholder': 'Paste a Base64 string or full data URI here...',
+	'ui.image_from_base64.output_placeholder': 'Decoded image preview appears here...',
+	'ui.image_from_base64.stat.output_type': 'Output type',
+	'ui.image_from_base64.stat.output_type_helper': 'Detected or fallback MIME',
+	'ui.image_from_base64.stat.output_size': 'Output size',
+	'ui.image_from_base64.stat.output_size_helper': 'Decoded binary size',
+	'ui.image_from_base64.stat.flags': 'Normalization',
+	'ui.image_from_base64.stat.flags_helper': 'Prefix, spaces, and padding',
+	'ui.image_from_base64.input_cleared': 'Base64 input cleared',
+	'ui.image_from_base64.sample_loaded': 'Sample Base64 loaded',
+	'ui.image_from_base64.copy_empty': 'Nothing to copy',
+	'ui.image_from_base64.copy_data_url_success': 'Data URL copied',
+	'ui.image_from_base64.copy_error': 'Copy failed',
+	'ui.image_from_base64.copy_base64_success': 'Normalized Base64 copied',
+	'ui.image_from_base64.download_empty': 'Nothing to download',
+	'ui.image_from_base64.download_success': 'Downloaded {filename}',
+	'ui.image_from_base64.download_error': 'Download failed',
+	'ui.image_from_base64.decode_failed': 'Base64 image decode failed',
+	'ui.image_from_base64.error.empty': 'Paste a Base64 string to decode.',
+	'ui.image_from_base64.error.invalid_mime':
+		'The data URI declares an unsupported image MIME type.',
+	'ui.image_from_base64.error.invalid_characters':
+		'The input contains characters that are not valid Base64.',
+	'ui.image_from_base64.error.invalid_padding':
+		'Padding must appear only at the end of the Base64 input.',
+	'ui.image_from_base64.error.invalid_length':
+		'The Base64 length is invalid and cannot be decoded.',
+	'ui.image_from_base64.flag.data_uri': 'Data URI',
+	'ui.image_from_base64.flag.whitespace': 'Spaces removed',
+	'ui.image_from_base64.flag.padding': 'Padding fixed',
+	'ui.image_from_base64.flag.fallback': 'Fallback MIME',
+	'ui.image_from_base64.flag.clean': 'No fixes',
+	'ui.image_from_base64.sample': 'Load sample',
+	'ui.image_from_base64.clear': 'Clear',
+	'ui.image_from_base64.fallback_mime': 'Fallback output type',
+	'ui.image_from_base64.processing': 'Decoding...',
+	'ui.image_from_base64.copy_base64': 'Copy Base64',
+	'ui.image_from_base64.copy_data_url': 'Copy data URL',
+	'ui.image_from_base64.download': 'Download',
+	'ui.image_from_base64.output_preview_alt': 'Decoded image preview',
 
 	// ── JSON tools ──────────────────────────────────────────────────────────
 	'tool.json-formatter.display_name': 'JSON Formatter',

--- a/src/lib/i18n/registry/es.ts
+++ b/src/lib/i18n/registry/es.ts
@@ -4477,6 +4477,165 @@ const registryEs: Record<string, string> = {
 	'ui.image_converter.copy_output': 'Copiar URL de datos',
 	'ui.image_converter.download': 'Descargar',
 	'ui.image_converter.output_placeholder': 'La salida convertida aparecerá aquí...',
+	'tool.image-to-base64.display_name': 'Imagen a Base64',
+	'tool.image-to-base64.tagline':
+		'Convierte imágenes en Base64 puro o en data URI lista para pegar',
+	'tool.image-to-base64.description':
+		'Convierte imágenes a cadenas Base64 o data URI completas directamente en tu navegador. Copia el resultado, descarga archivos `.txt` y mantén todo el procesamiento local incluso con archivos grandes.',
+	'tool.image-to-base64.primary_keyword': 'imagen a base64',
+	'tool.image-to-base64.meta_title': 'Imagen a Base64 — Convertidor Data URI | fmtly.dev',
+	'tool.image-to-base64.meta_description':
+		'Convierte imágenes a Base64 o data URI completas en tu navegador. Privado, rápido, con copia, descarga y Web Worker para archivos grandes.',
+	'tool.image-to-base64.operation': 'Convertir imagen a Base64',
+	'tool.image-to-base64.faq.0.question': '¿La imagen sale del navegador?',
+	'tool.image-to-base64.faq.0.answer':
+		'No. La conversión se realiza completamente en tu navegador y el archivo nunca se sube a un servidor.',
+	'tool.image-to-base64.faq.1.question': '¿Cuál es la diferencia entre Base64 y data URI?',
+	'tool.image-to-base64.faq.1.answer':
+		'Base64 contiene solo la carga codificada. Una data URI añade el prefijo MIME, como `data:image/png;base64,`, para que puedas pegarla directamente en HTML, CSS o JSON.',
+	'tool.image-to-base64.faq.2.question': '¿Qué formatos de imagen se admiten?',
+	'tool.image-to-base64.faq.2.answer':
+		'La herramienta acepta formatos comunes del navegador, incluidos PNG, JPEG, WebP, GIF, BMP, AVIF, SVG e ICO.',
+	'tool.image-to-base64.faq.3.question': '¿Cómo se manejan las imágenes grandes?',
+	'tool.image-to-base64.faq.3.answer':
+		'Cuando la entrada supera 500KB, la codificación se mueve a un Web Worker para mantener la interfaz fluida.',
+	'tool.image-to-base64.use_case.0':
+		'Insertar iconos y pequeños recursos inline en HTML, CSS o cargas JSON',
+	'tool.image-to-base64.use_case.1':
+		'Generar data URI listas para pegar en prototipos, emails o bundles pequeños',
+	'tool.image-to-base64.use_case.2':
+		'Comparar el crecimiento del tamaño antes de incrustar imágenes en texto',
+	'tool.image-to-base64.use_case.3':
+		'Convertir imágenes privadas a Base64 sin usar servicios externos',
+	'tool.image-from-base64.display_name': 'Base64 a Imagen',
+	'tool.image-from-base64.tagline':
+		'Decodifica Base64 o data URI en imágenes descargables y previsualizadas',
+	'tool.image-from-base64.description':
+		'Pega Base64 puro o una data URI completa para reconstruir imágenes directamente en el navegador. La herramienta corrige espacios y padding cuando es seguro, detecta tipos de imagen comunes y permite descargar al instante.',
+	'tool.image-from-base64.primary_keyword': 'base64 a imagen',
+	'tool.image-from-base64.meta_title': 'Base64 a Imagen — Decodificar Data URI | fmtly.dev',
+	'tool.image-from-base64.meta_description':
+		'Decodifica Base64 o data URI en imágenes descargables en tu navegador. Detecta MIME, corrige padding y espacios, y mantiene todo privado.',
+	'tool.image-from-base64.operation': 'Decodificar imagen Base64',
+	'tool.image-from-base64.faq.0.question':
+		'¿Puedo pegar una data URI completa en lugar de Base64 puro?',
+	'tool.image-from-base64.faq.0.answer':
+		'Sí. Puedes pegar cadenas como `data:image/png;base64,...` y la herramienta extraerá automáticamente la carga Base64.',
+	'tool.image-from-base64.faq.1.question': '¿Qué pasa si falta el tipo MIME?',
+	'tool.image-from-base64.faq.1.answer':
+		'La herramienta intenta detectar el tipo real desde los bytes decodificados. Si no puede, usa el tipo MIME alternativo que selecciones.',
+	'tool.image-from-base64.faq.2.question': '¿Corrige espacios o padding faltante?',
+	'tool.image-from-base64.faq.2.answer':
+		'Sí. Elimina espacios, normaliza caracteres URL-safe y añade padding final cuando hace falta. Esos ajustes se muestran en el resumen de normalización.',
+	'tool.image-from-base64.faq.3.question': '¿El contenido Base64 sigue siendo privado?',
+	'tool.image-from-base64.faq.3.answer':
+		'Sí. La decodificación ocurre por completo en tu navegador y no se envía ningún contenido a un backend.',
+	'tool.image-from-base64.use_case.0':
+		'Recuperar imágenes desde cargas JSON, HTML o archivos de configuración',
+	'tool.image-from-base64.use_case.1':
+		'Comprobar rápidamente si una cadena Base64 contiene PNG, JPEG, SVG u otra imagen',
+	'tool.image-from-base64.use_case.2': 'Descargar imágenes incrustadas compartidas como data URI',
+	'tool.image-from-base64.use_case.3': 'Normalizar Base64 heredado con espacios o padding faltante',
+	'ui.image_to_base64.upload': 'Subir imagen',
+	'ui.image_to_base64.clear': 'Limpiar',
+	'ui.image_to_base64.no_file': 'No hay imagen seleccionada',
+	'ui.image_to_base64.source_status': '{size} · {format}',
+	'ui.image_to_base64.output_status':
+		'{base64Chars} caracteres Base64 · {dataUrlChars} caracteres de data URI',
+	'ui.image_to_base64.worker_active':
+		'Imagen grande detectada (>{size}). La conversión se ejecuta en un Web Worker.',
+	'ui.image_to_base64.worker_used': 'Procesado fuera del hilo principal',
+	'ui.image_to_base64.worker_failed':
+		'Falló la codificación en Worker. Se usará el hilo principal.',
+	'ui.image_to_base64.file_read_error': 'No se pudo cargar la imagen',
+	'ui.image_to_base64.file_loaded': '{name} cargado',
+	'ui.image_to_base64.input_cleared': 'Entrada de imagen limpiada',
+	'ui.image_to_base64.copy_empty': 'No hay nada que copiar',
+	'ui.image_to_base64.copy_success': 'Salida copiada',
+	'ui.image_to_base64.copy_data_uri_success': 'Data URI copiada',
+	'ui.image_to_base64.copy_error': 'Error al copiar',
+	'ui.image_to_base64.download_empty': 'No hay nada que descargar',
+	'ui.image_to_base64.download_success': '{filename} descargado',
+	'ui.image_to_base64.download_error': 'Error en la descarga',
+	'ui.image_to_base64.drop_title': 'Suelta una imagen aquí',
+	'ui.image_to_base64.drop_hint':
+		'PNG, JPEG, WebP, GIF, SVG, BMP, AVIF e ICO permanecen en este navegador.',
+	'ui.image_to_base64.source_preview_alt': 'Vista previa de la imagen de origen',
+	'ui.image_to_base64.privacy_note':
+		'La codificación es local; tu imagen nunca sale del navegador.',
+	'ui.image_to_base64.performance_note':
+		'Las entradas grandes usan un Web Worker a partir de {size}.',
+	'ui.image_to_base64.stat.file_size': 'Tamaño de imagen',
+	'ui.image_to_base64.stat.file_size_helper': 'entrada solo en navegador',
+	'ui.image_to_base64.stat.base64_length': 'Longitud Base64',
+	'ui.image_to_base64.stat.base64_length_helper': 'caracteres sin prefijo',
+	'ui.image_to_base64.stat.expansion': 'Crecimiento de carga',
+	'ui.image_to_base64.stat.expansion_helper': 'sobrecarga esperada de Base64',
+	'ui.image_to_base64.processing': 'Codificando...',
+	'ui.image_to_base64.copy_base64': 'Copiar Base64',
+	'ui.image_to_base64.copy_data_uri': 'Copiar data URI',
+	'ui.image_to_base64.download_base64': 'Descargar .txt',
+	'ui.image_to_base64.download_data_uri': 'Descargar data URI',
+	'ui.image_to_base64.base64_output': 'Salida Base64',
+	'ui.image_to_base64.output_placeholder': 'El Base64 codificado aparecerá aquí...',
+	'ui.image_to_base64.data_uri_output': 'Salida data URI',
+	'ui.image_to_base64.data_uri_placeholder': 'La data URI aparecerá aquí...',
+	'ui.image_to_base64.unsupported_image': 'Formato de imagen no compatible',
+	'ui.image_to_base64.empty_image': 'El archivo de imagen está vacío',
+	'ui.image_to_base64.convert_failed': 'No se pudo convertir la imagen a Base64',
+	'ui.image_from_base64.input_status': '{size} · {characters} caracteres',
+	'ui.image_from_base64.output_status': '{size} · {type}',
+	'ui.image_from_base64.worker_active':
+		'Entrada Base64 grande detectada (>{size}). La decodificación se ejecuta en un Web Worker.',
+	'ui.image_from_base64.worker_used': 'Procesado fuera del hilo principal',
+	'ui.image_from_base64.worker_failed':
+		'Falló la decodificación en Worker. Se usará el hilo principal.',
+	'ui.image_from_base64.privacy_note':
+		'Los bytes decodificados permanecen en tu navegador; no se sube nada.',
+	'ui.image_from_base64.performance_note':
+		'Las cadenas Base64 grandes usan un Web Worker a partir de {size}.',
+	'ui.image_from_base64.input_placeholder':
+		'Pega aquí una cadena Base64 o una data URI completa...',
+	'ui.image_from_base64.output_placeholder':
+		'La vista previa de la imagen decodificada aparecerá aquí...',
+	'ui.image_from_base64.stat.output_type': 'Tipo de salida',
+	'ui.image_from_base64.stat.output_type_helper': 'MIME detectado o alternativo',
+	'ui.image_from_base64.stat.output_size': 'Tamaño de salida',
+	'ui.image_from_base64.stat.output_size_helper': 'Tamaño binario decodificado',
+	'ui.image_from_base64.stat.flags': 'Normalización',
+	'ui.image_from_base64.stat.flags_helper': 'Prefijo, espacios y padding',
+	'ui.image_from_base64.input_cleared': 'Entrada Base64 limpiada',
+	'ui.image_from_base64.sample_loaded': 'Base64 de ejemplo cargado',
+	'ui.image_from_base64.copy_empty': 'No hay nada que copiar',
+	'ui.image_from_base64.copy_data_url_success': 'URL de datos copiada',
+	'ui.image_from_base64.copy_error': 'Error al copiar',
+	'ui.image_from_base64.copy_base64_success': 'Base64 normalizado copiado',
+	'ui.image_from_base64.download_empty': 'No hay nada que descargar',
+	'ui.image_from_base64.download_success': '{filename} descargado',
+	'ui.image_from_base64.download_error': 'Error en la descarga',
+	'ui.image_from_base64.decode_failed': 'No se pudo decodificar la imagen Base64',
+	'ui.image_from_base64.error.empty': 'Pega una cadena Base64 para decodificar.',
+	'ui.image_from_base64.error.invalid_mime':
+		'La data URI declara un tipo MIME de imagen no compatible.',
+	'ui.image_from_base64.error.invalid_characters':
+		'La entrada contiene caracteres que no son Base64 válidos.',
+	'ui.image_from_base64.error.invalid_padding':
+		'El padding solo puede aparecer al final de la entrada Base64.',
+	'ui.image_from_base64.error.invalid_length':
+		'La longitud Base64 no es válida y no puede decodificarse.',
+	'ui.image_from_base64.flag.data_uri': 'Data URI',
+	'ui.image_from_base64.flag.whitespace': 'Espacios eliminados',
+	'ui.image_from_base64.flag.padding': 'Padding corregido',
+	'ui.image_from_base64.flag.fallback': 'MIME alternativo',
+	'ui.image_from_base64.flag.clean': 'Sin correcciones',
+	'ui.image_from_base64.sample': 'Cargar ejemplo',
+	'ui.image_from_base64.clear': 'Limpiar',
+	'ui.image_from_base64.fallback_mime': 'Tipo de salida alternativo',
+	'ui.image_from_base64.processing': 'Decodificando...',
+	'ui.image_from_base64.copy_base64': 'Copiar Base64',
+	'ui.image_from_base64.copy_data_url': 'Copiar URL de datos',
+	'ui.image_from_base64.download': 'Descargar',
+	'ui.image_from_base64.output_preview_alt': 'Vista previa de la imagen decodificada',
 	'ui.image_resizer.drop_title': 'Suelta una imagen aquí o selecciónala',
 	'ui.image_resizer.drop_hint':
 		'Todo se procesa localmente en tu navegador. No se sube ninguna imagen.',

--- a/src/lib/i18n/registry/fr.ts
+++ b/src/lib/i18n/registry/fr.ts
@@ -4506,6 +4506,166 @@ const registryFr: Record<string, string> = {
 	'ui.image_converter.copy_output': 'Copier l’URL de données',
 	'ui.image_converter.download': 'Télécharger',
 	'ui.image_converter.output_placeholder': 'La sortie convertie apparaîtra ici...',
+	'tool.image-to-base64.display_name': 'Image vers Base64',
+	'tool.image-to-base64.tagline':
+		'Transformez des images en Base64 brut ou en data URI prêt à coller',
+	'tool.image-to-base64.description':
+		'Convertissez des images en chaînes Base64 ou en data URI complets directement dans votre navigateur. Prévisualisez le fichier source, copiez le Base64 brut, exportez un data URI prêt pour HTML/CSS et gardez tout local.',
+	'tool.image-to-base64.primary_keyword': 'image vers base64',
+	'tool.image-to-base64.meta_title': 'Image vers Base64 — Convertisseur Data URI | fmtly.dev',
+	'tool.image-to-base64.meta_description':
+		'Convertissez des images en Base64 ou en data URI directement dans votre navigateur. Privé, rapide, avec prévisualisation, copie et Web Worker pour gros fichiers.',
+	'tool.image-to-base64.operation': 'Convertir une image en Base64',
+	'tool.image-to-base64.faq.0.question': 'Mon image quitte-t-elle le navigateur ?',
+	'tool.image-to-base64.faq.0.answer':
+		'Non. L’encodage se fait entièrement localement dans votre navigateur. Aucun fichier image n’est téléversé.',
+	'tool.image-to-base64.faq.1.question': 'Quelle est la différence entre Base64 brut et data URI ?',
+	'tool.image-to-base64.faq.1.answer':
+		'Le Base64 brut ne contient que les caractères encodés. Un data URI ajoute le préfixe MIME, par exemple data:image/png;base64,..., afin d’être collé directement dans HTML, CSS ou JSON.',
+	'tool.image-to-base64.faq.2.question': 'Quels formats d’image sont pris en charge ?',
+	'tool.image-to-base64.faq.2.answer':
+		'Vous pouvez charger PNG, JPEG, WebP, GIF, BMP, AVIF, SVG et ICO. Le type MIME détecté est conservé dans le data URI généré.',
+	'tool.image-to-base64.faq.3.question': 'Comment les images volumineuses sont-elles gérées ?',
+	'tool.image-to-base64.faq.3.answer':
+		'Au-delà de 500KB, l’encodage bascule dans un Web Worker pour que l’interface reste réactive.',
+	'tool.image-to-base64.use_case.0':
+		'Intégrer des icônes et petits assets en ligne dans HTML, CSS ou des payloads JSON',
+	'tool.image-to-base64.use_case.1':
+		'Générer rapidement des data URI pour prototypes, e-mails ou composants sans pipeline de build',
+	'tool.image-to-base64.use_case.2':
+		'Vérifier le poids et la longueur Base64 avant d’embarquer une image',
+	'tool.image-to-base64.use_case.3':
+		'Copier séparément le Base64 brut ou le data URI complet selon le contexte',
+	'tool.image-from-base64.display_name': 'Base64 vers Image',
+	'tool.image-from-base64.tagline':
+		'Décodez des chaînes Base64 ou data URI en images téléchargeables',
+	'tool.image-from-base64.description':
+		'Collez une chaîne Base64 brute ou un data URI complet pour reconstruire une image localement dans votre navigateur. Détection du type, normalisation des espaces/paddings, aperçu direct et téléchargement immédiat.',
+	'tool.image-from-base64.primary_keyword': 'base64 vers image',
+	'tool.image-from-base64.meta_title': 'Base64 vers Image — Décoder les Data URI | fmtly.dev',
+	'tool.image-from-base64.meta_description':
+		'Décodez des chaînes Base64 ou data URI en images directement dans le navigateur. Détection MIME, aperçu, téléchargement et Web Worker pour gros contenus.',
+	'tool.image-from-base64.operation': 'Décoder une image Base64',
+	'tool.image-from-base64.faq.0.question':
+		'Puis-je coller un data URI complet au lieu du Base64 brut ?',
+	'tool.image-from-base64.faq.0.answer':
+		'Oui. L’outil accepte à la fois les chaînes Base64 brutes et les data URI complets comme data:image/png;base64,....',
+	'tool.image-from-base64.faq.1.question': 'Que se passe-t-il si le type MIME manque ?',
+	'tool.image-from-base64.faq.1.answer':
+		'L’outil tente d’identifier le format réel à partir des octets décodés. Si ce n’est pas possible, il utilise le type de secours que vous avez choisi.',
+	'tool.image-from-base64.faq.2.question': 'Corrige-t-il les espaces ou le padding manquant ?',
+	'tool.image-from-base64.faq.2.answer':
+		'Oui. Les espaces sont supprimés, le padding manquant est ajouté quand c’est sûr, et ces corrections sont affichées dans les métriques de normalisation.',
+	'tool.image-from-base64.faq.3.question': 'L’entrée Base64 reste-t-elle privée ?',
+	'tool.image-from-base64.faq.3.answer':
+		'Oui. Le décodage se fait entièrement dans le navigateur et rien n’est envoyé à un serveur.',
+	'tool.image-from-base64.use_case.0':
+		'Restaurer des images depuis des data URI copiés de CSS, HTML ou réponses d’API',
+	'tool.image-from-base64.use_case.1':
+		'Vérifier qu’un payload Base64 généré côté backend reconstruit bien une image valide',
+	'tool.image-from-base64.use_case.2':
+		'Décoder des images collées dans docs, snippets ou fixtures de tests',
+	'tool.image-from-base64.use_case.3':
+		'Télécharger des images reconstruites sans scripts ni outils en ligne de commande',
+	'ui.image_to_base64.upload': 'Importer une image',
+	'ui.image_to_base64.clear': 'Effacer',
+	'ui.image_to_base64.no_file': 'Aucune image sélectionnée',
+	'ui.image_to_base64.source_status': '{size} · {format}',
+	'ui.image_to_base64.output_status':
+		'{base64Chars} caractères Base64 · {dataUrlChars} caractères data URI',
+	'ui.image_to_base64.worker_active':
+		'Grande image détectée (>{size}). L’encodage s’exécute dans un Web Worker.',
+	'ui.image_to_base64.worker_used': 'Traité hors du fil principal',
+	'ui.image_to_base64.worker_failed':
+		'Échec de l’encodage dans le Worker. Retour au traitement sur le fil principal.',
+	'ui.image_to_base64.file_read_error': 'Impossible de charger le fichier image',
+	'ui.image_to_base64.file_loaded': '{name} chargé',
+	'ui.image_to_base64.input_cleared': 'Entrée image effacée',
+	'ui.image_to_base64.copy_empty': 'Rien à copier',
+	'ui.image_to_base64.copy_success': 'Sortie copiée',
+	'ui.image_to_base64.copy_data_uri_success': 'Data URI copié',
+	'ui.image_to_base64.copy_error': 'Échec de la copie',
+	'ui.image_to_base64.download_empty': 'Rien à télécharger',
+	'ui.image_to_base64.download_success': '{filename} téléchargé',
+	'ui.image_to_base64.download_error': 'Échec du téléchargement',
+	'ui.image_to_base64.drop_title': 'Déposez une image ici',
+	'ui.image_to_base64.drop_hint':
+		'PNG, JPEG, WebP, GIF, SVG, BMP, AVIF et ICO restent dans ce navigateur.',
+	'ui.image_to_base64.source_preview_alt': 'Aperçu de l’image source',
+	'ui.image_to_base64.privacy_note':
+		'L’encodage est local ; votre image ne quitte jamais le navigateur.',
+	'ui.image_to_base64.performance_note':
+		'Les grandes entrées utilisent un Web Worker au-dessus de {size}.',
+	'ui.image_to_base64.stat.file_size': 'Taille de l’image',
+	'ui.image_to_base64.stat.file_size_helper': 'entrée traitée localement',
+	'ui.image_to_base64.stat.base64_length': 'Longueur Base64',
+	'ui.image_to_base64.stat.base64_length_helper': 'caractères sans préfixe',
+	'ui.image_to_base64.stat.expansion': 'Croissance du payload',
+	'ui.image_to_base64.stat.expansion_helper': 'surcoût Base64 attendu',
+	'ui.image_to_base64.processing': 'Encodage...',
+	'ui.image_to_base64.copy_base64': 'Copier le Base64',
+	'ui.image_to_base64.copy_data_uri': 'Copier le data URI',
+	'ui.image_to_base64.download_base64': 'Télécharger le .txt',
+	'ui.image_to_base64.download_data_uri': 'Télécharger le data URI',
+	'ui.image_to_base64.base64_output': 'Sortie Base64',
+	'ui.image_to_base64.output_placeholder': 'Le Base64 encodé apparaît ici...',
+	'ui.image_to_base64.data_uri_output': 'Sortie data URI',
+	'ui.image_to_base64.data_uri_placeholder': 'Le data URI apparaît ici...',
+	'ui.image_to_base64.unsupported_image': 'Format d’image non pris en charge',
+	'ui.image_to_base64.empty_image': 'Le fichier image est vide',
+	'ui.image_to_base64.convert_failed': 'Impossible de convertir l’image en Base64',
+	'ui.image_from_base64.input_status': '{size} · {characters} caractères',
+	'ui.image_from_base64.output_status': '{size} · {type}',
+	'ui.image_from_base64.worker_active':
+		'Grande entrée Base64 détectée (>{size}). Le décodage s’exécute dans un Web Worker.',
+	'ui.image_from_base64.worker_used': 'Traité hors du fil principal',
+	'ui.image_from_base64.worker_failed':
+		'Échec du décodage dans le Worker. Retour au traitement sur le fil principal.',
+	'ui.image_from_base64.privacy_note':
+		'Les octets décodés restent dans votre navigateur ; rien n’est téléversé.',
+	'ui.image_from_base64.performance_note':
+		'Les grandes chaînes Base64 utilisent un Web Worker au-dessus de {size}.',
+	'ui.image_from_base64.input_placeholder':
+		'Collez ici une chaîne Base64 ou un data URI complet...',
+	'ui.image_from_base64.output_placeholder': 'L’aperçu de l’image décodée apparaît ici...',
+	'ui.image_from_base64.stat.output_type': 'Type de sortie',
+	'ui.image_from_base64.stat.output_type_helper': 'MIME détecté ou de secours',
+	'ui.image_from_base64.stat.output_size': 'Taille de sortie',
+	'ui.image_from_base64.stat.output_size_helper': 'Taille binaire décodée',
+	'ui.image_from_base64.stat.flags': 'Normalisation',
+	'ui.image_from_base64.stat.flags_helper': 'Préfixe, espaces et padding',
+	'ui.image_from_base64.input_cleared': 'Entrée Base64 effacée',
+	'ui.image_from_base64.sample_loaded': 'Exemple Base64 chargé',
+	'ui.image_from_base64.copy_empty': 'Rien à copier',
+	'ui.image_from_base64.copy_data_url_success': 'URL de données copiée',
+	'ui.image_from_base64.copy_error': 'Échec de la copie',
+	'ui.image_from_base64.copy_base64_success': 'Base64 normalisé copié',
+	'ui.image_from_base64.download_empty': 'Rien à télécharger',
+	'ui.image_from_base64.download_success': '{filename} téléchargé',
+	'ui.image_from_base64.download_error': 'Échec du téléchargement',
+	'ui.image_from_base64.decode_failed': 'Échec du décodage de l’image Base64',
+	'ui.image_from_base64.error.empty': 'Collez une chaîne Base64 à décoder.',
+	'ui.image_from_base64.error.invalid_mime':
+		'Le data URI déclare un type MIME image non pris en charge.',
+	'ui.image_from_base64.error.invalid_characters':
+		'L’entrée contient des caractères qui ne sont pas valides en Base64.',
+	'ui.image_from_base64.error.invalid_padding':
+		'Le padding doit apparaître uniquement à la fin de l’entrée Base64.',
+	'ui.image_from_base64.error.invalid_length':
+		'La longueur Base64 est invalide et ne peut pas être décodée.',
+	'ui.image_from_base64.flag.data_uri': 'Data URI',
+	'ui.image_from_base64.flag.whitespace': 'Espaces supprimés',
+	'ui.image_from_base64.flag.padding': 'Padding corrigé',
+	'ui.image_from_base64.flag.fallback': 'MIME de secours',
+	'ui.image_from_base64.flag.clean': 'Aucune correction',
+	'ui.image_from_base64.sample': 'Charger un exemple',
+	'ui.image_from_base64.clear': 'Effacer',
+	'ui.image_from_base64.fallback_mime': 'Type de sortie de secours',
+	'ui.image_from_base64.processing': 'Décodage...',
+	'ui.image_from_base64.copy_base64': 'Copier le Base64',
+	'ui.image_from_base64.copy_data_url': 'Copier l’URL de données',
+	'ui.image_from_base64.download': 'Télécharger',
+	'ui.image_from_base64.output_preview_alt': 'Aperçu de l’image décodée',
 	'ui.image_resizer.drop_title': 'Déposez une image ici ou parcourez vos fichiers',
 	'ui.image_resizer.drop_hint':
 		'Votre image reste locale dans ce navigateur. Rien n’est téléversé.',

--- a/src/lib/i18n/registry/it.ts
+++ b/src/lib/i18n/registry/it.ts
@@ -4369,6 +4369,163 @@ const registryIt: Record<string, string> = {
 	'tool.image-format-converter.use_case.2': 'Esportare anteprime GIF leggere da grafiche statiche',
 	'tool.image-format-converter.use_case.3':
 		'Normalizzare immagini fornite dai clienti prima di CMS o API',
+	'tool.image-to-base64.display_name': 'Immagine in Base64',
+	'tool.image-to-base64.tagline':
+		'Trasforma immagini in Base64 puro o in data URI pronti da incollare',
+	'tool.image-to-base64.description':
+		'Converti PNG, JPEG, WebP, GIF, SVG, BMP, AVIF e ICO in stringhe Base64 o data URI completi direttamente nel browser. Copia l’output, scaricalo come file di testo e mantieni tutto locale.',
+	'tool.image-to-base64.primary_keyword': 'immagine in base64',
+	'tool.image-to-base64.meta_title': 'Immagine in Base64 — Convertitore Data URI | fmtly.dev',
+	'tool.image-to-base64.meta_description':
+		'Converti immagini in Base64 o data URI completi nel browser. Veloce, privato, con copia, download e Web Worker per file grandi.',
+	'tool.image-to-base64.operation': 'Converti immagine in Base64',
+	'tool.image-to-base64.faq.0.question': 'La mia immagine lascia il browser?',
+	'tool.image-to-base64.faq.0.answer':
+		'No. La conversione in Base64 avviene interamente nel browser e nessun file viene inviato a un server.',
+	'tool.image-to-base64.faq.1.question': 'Qual è la differenza tra Base64 puro e data URI?',
+	'tool.image-to-base64.faq.1.answer':
+		'Il Base64 puro contiene solo il payload codificato. Il data URI aggiunge il prefisso MIME, per esempio `data:image/png;base64,`, così puoi incollarlo direttamente in HTML, CSS o JSON.',
+	'tool.image-to-base64.faq.2.question': 'Quali formati immagine sono supportati?',
+	'tool.image-to-base64.faq.2.answer':
+		'Puoi caricare PNG, JPEG, WebP, GIF, BMP, AVIF, SVG e ICO. Il tool mantiene il MIME originale nell’output.',
+	'tool.image-to-base64.faq.3.question': 'Come vengono gestite immagini grandi?',
+	'tool.image-to-base64.faq.3.answer':
+		'Gli input oltre 500KB vengono elaborati in un Web Worker per mantenere l’interfaccia reattiva durante la codifica.',
+	'tool.image-to-base64.use_case.0':
+		'Incorporare icone e asset piccoli inline in payload HTML, CSS o JSON',
+	'tool.image-to-base64.use_case.1': 'Creare rapidamente data URI per prototipi, email o temi',
+	'tool.image-to-base64.use_case.2':
+		'Confrontare l’overhead Base64 prima di inserire asset in configurazioni o seed',
+	'tool.image-to-base64.use_case.3':
+		'Condividere asset come testo quando non è pratico inviare file binari',
+	'tool.image-from-base64.display_name': 'Base64 in Immagine',
+	'tool.image-from-base64.tagline':
+		'Decodifica Base64 o data URI in immagini scaricabili con rilevamento del MIME',
+	'tool.image-from-base64.description':
+		'Incolla Base64 puro o data URI completi per ricostruire immagini direttamente nel browser. Rileva automaticamente PNG, JPEG, WebP, GIF, AVIF, SVG, BMP e ICO, corregge spazi o padding mancanti e offre download immediato.',
+	'tool.image-from-base64.primary_keyword': 'base64 in immagine',
+	'tool.image-from-base64.meta_title': 'Base64 in Immagine — Decodifica Data URI | fmtly.dev',
+	'tool.image-from-base64.meta_description':
+		'Decodifica Base64 o data URI in immagini nel browser. Rileva il tipo immagine, corregge padding e spazi e consente il download istantaneo.',
+	'tool.image-from-base64.operation': 'Decodifica immagine Base64',
+	'tool.image-from-base64.faq.0.question':
+		'Posso incollare un data URI completo invece del Base64 puro?',
+	'tool.image-from-base64.faq.0.answer':
+		'Sì. Il tool accetta sia payload Base64 grezzi sia data URI completi e rimuove automaticamente il prefisso quando necessario.',
+	'tool.image-from-base64.faq.1.question': 'Cosa succede se manca il tipo MIME?',
+	'tool.image-from-base64.faq.1.answer':
+		'Il tool prova prima a rilevare il tipo immagine dai byte decodificati. Se non ci riesce, usa il tipo di fallback che scegli nella UI.',
+	'tool.image-from-base64.faq.2.question': 'Corregge spazi o padding mancanti?',
+	'tool.image-from-base64.faq.2.answer':
+		'Sì. Spazi, interruzioni di riga e padding mancante possono essere normalizzati automaticamente, con indicatori nella UI che mostrano quali correzioni sono state applicate.',
+	'tool.image-from-base64.faq.3.question': 'L’input Base64 resta privato?',
+	'tool.image-from-base64.faq.3.answer':
+		'Sì. L’intera decodifica avviene localmente nel browser, quindi il contenuto Base64 non lascia mai il dispositivo.',
+	'tool.image-from-base64.use_case.0':
+		'Ripristinare immagini da payload API o fixture salvate come Base64',
+	'tool.image-from-base64.use_case.1':
+		'Verificare data URI copiati da HTML, CSS o strumenti di design',
+	'tool.image-from-base64.use_case.2':
+		'Scaricare rapidamente immagini inviate in JSON o log invece che come file',
+	'tool.image-from-base64.use_case.3':
+		'Riparare stringhe Base64 con ritorni a capo o padding mancante prima dell’esportazione',
+	'ui.image_to_base64.upload': 'Carica immagine',
+	'ui.image_to_base64.clear': 'Cancella',
+	'ui.image_to_base64.no_file': 'Nessuna immagine selezionata',
+	'ui.image_to_base64.source_status': '{size} · {format}',
+	'ui.image_to_base64.output_status':
+		'{base64Chars} caratteri Base64 · {dataUrlChars} caratteri data URI',
+	'ui.image_to_base64.worker_active':
+		'Immagine grande rilevata (>{size}). La conversione usa un Web Worker.',
+	'ui.image_to_base64.worker_used': 'Elaborato fuori dal thread principale',
+	'ui.image_to_base64.worker_failed':
+		'Codifica nel Worker non riuscita. Passaggio al thread principale.',
+	'ui.image_to_base64.file_read_error': 'Impossibile caricare il file immagine',
+	'ui.image_to_base64.file_loaded': '{name} caricato',
+	'ui.image_to_base64.input_cleared': 'Input immagine cancellato',
+	'ui.image_to_base64.copy_empty': 'Niente da copiare',
+	'ui.image_to_base64.copy_success': 'Output copiato',
+	'ui.image_to_base64.copy_data_uri_success': 'Data URI copiato',
+	'ui.image_to_base64.copy_error': 'Copia non riuscita',
+	'ui.image_to_base64.download_empty': 'Niente da scaricare',
+	'ui.image_to_base64.download_success': '{filename} scaricato',
+	'ui.image_to_base64.download_error': 'Download non riuscito',
+	'ui.image_to_base64.drop_title': 'Rilascia un’immagine qui',
+	'ui.image_to_base64.drop_hint':
+		'PNG, JPEG, WebP, GIF, SVG, BMP, AVIF e ICO restano in questo browser.',
+	'ui.image_to_base64.source_preview_alt': 'Anteprima immagine sorgente',
+	'ui.image_to_base64.privacy_note': 'La codifica è locale; l’immagine non lascia mai il browser.',
+	'ui.image_to_base64.performance_note': 'Gli input grandi usano un Web Worker sopra {size}.',
+	'ui.image_to_base64.stat.file_size': 'Dimensione immagine',
+	'ui.image_to_base64.stat.file_size_helper': 'input solo browser',
+	'ui.image_to_base64.stat.base64_length': 'Lunghezza Base64',
+	'ui.image_to_base64.stat.base64_length_helper': 'caratteri senza prefisso',
+	'ui.image_to_base64.stat.expansion': 'Crescita payload',
+	'ui.image_to_base64.stat.expansion_helper': 'overhead Base64 previsto',
+	'ui.image_to_base64.processing': 'Codifica...',
+	'ui.image_to_base64.copy_base64': 'Copia Base64',
+	'ui.image_to_base64.copy_data_uri': 'Copia data URI',
+	'ui.image_to_base64.download_base64': 'Scarica .txt',
+	'ui.image_to_base64.download_data_uri': 'Scarica data URI',
+	'ui.image_to_base64.base64_output': 'Output Base64',
+	'ui.image_to_base64.output_placeholder': 'Il Base64 codificato apparirà qui...',
+	'ui.image_to_base64.data_uri_output': 'Output data URI',
+	'ui.image_to_base64.data_uri_placeholder': 'Il data URI apparirà qui...',
+	'ui.image_to_base64.unsupported_image': 'Formato immagine non supportato',
+	'ui.image_to_base64.empty_image': 'Il file immagine è vuoto',
+	'ui.image_to_base64.convert_failed': 'Impossibile convertire l’immagine in Base64',
+	'ui.image_from_base64.input_status': '{size} · {characters} caratteri',
+	'ui.image_from_base64.output_status': '{size} · {type}',
+	'ui.image_from_base64.worker_active':
+		'Input Base64 grande rilevato (>{size}). La decodifica usa un Web Worker.',
+	'ui.image_from_base64.worker_used': 'Elaborato fuori dal thread principale',
+	'ui.image_from_base64.worker_failed':
+		'Decodifica nel Worker non riuscita. Passaggio al thread principale.',
+	'ui.image_from_base64.privacy_note':
+		'I byte dell’immagine decodificata restano nel browser; nulla viene caricato.',
+	'ui.image_from_base64.performance_note':
+		'Le stringhe Base64 grandi usano un Web Worker sopra {size}.',
+	'ui.image_from_base64.input_placeholder':
+		'Incolla qui una stringa Base64 o un data URI completo...',
+	'ui.image_from_base64.output_placeholder': 'L’anteprima immagine decodificata apparirà qui...',
+	'ui.image_from_base64.stat.output_type': 'Tipo output',
+	'ui.image_from_base64.stat.output_type_helper': 'MIME rilevato o di fallback',
+	'ui.image_from_base64.stat.output_size': 'Dimensione output',
+	'ui.image_from_base64.stat.output_size_helper': 'Dimensione binaria decodificata',
+	'ui.image_from_base64.stat.flags': 'Normalizzazione',
+	'ui.image_from_base64.stat.flags_helper': 'Prefisso, spazi e padding',
+	'ui.image_from_base64.input_cleared': 'Input Base64 cancellato',
+	'ui.image_from_base64.sample_loaded': 'Esempio Base64 caricato',
+	'ui.image_from_base64.copy_empty': 'Niente da copiare',
+	'ui.image_from_base64.copy_data_url_success': 'Data URL copiato',
+	'ui.image_from_base64.copy_error': 'Copia non riuscita',
+	'ui.image_from_base64.copy_base64_success': 'Base64 normalizzato copiato',
+	'ui.image_from_base64.download_empty': 'Niente da scaricare',
+	'ui.image_from_base64.download_success': '{filename} scaricato',
+	'ui.image_from_base64.download_error': 'Download non riuscito',
+	'ui.image_from_base64.decode_failed': 'Decodifica immagine Base64 non riuscita',
+	'ui.image_from_base64.error.empty': 'Incolla una stringa Base64 da decodificare.',
+	'ui.image_from_base64.error.invalid_mime':
+		'Il data URI dichiara un tipo MIME immagine non supportato.',
+	'ui.image_from_base64.error.invalid_characters':
+		'L’input contiene caratteri non validi per il Base64.',
+	'ui.image_from_base64.error.invalid_padding':
+		'Il padding deve comparire solo alla fine dell’input Base64.',
+	'ui.image_from_base64.error.invalid_length':
+		'La lunghezza Base64 non è valida e non può essere decodificata.',
+	'ui.image_from_base64.flag.data_uri': 'Data URI',
+	'ui.image_from_base64.flag.whitespace': 'Spazi rimossi',
+	'ui.image_from_base64.flag.padding': 'Padding corretto',
+	'ui.image_from_base64.flag.fallback': 'MIME di fallback',
+	'ui.image_from_base64.flag.clean': 'Nessuna correzione',
+	'ui.image_from_base64.sample': 'Carica esempio',
+	'ui.image_from_base64.clear': 'Cancella',
+	'ui.image_from_base64.fallback_mime': 'Tipo output di fallback',
+	'ui.image_from_base64.processing': 'Decodifica...',
+	'ui.image_from_base64.copy_base64': 'Copia Base64',
+	'ui.image_from_base64.copy_data_url': 'Copia data URL',
+	'ui.image_from_base64.download': 'Scarica',
+	'ui.image_from_base64.output_preview_alt': 'Anteprima immagine decodificata',
 	'ui.image_converter.upload': 'Carica immagine',
 	'ui.image_converter.clear': 'Cancella',
 	'ui.image_converter.no_file': 'Nessuna immagine selezionata',

--- a/src/lib/i18n/registry/tr.ts
+++ b/src/lib/i18n/registry/tr.ts
@@ -4448,6 +4448,160 @@ const registryTr: Record<string, string> = {
 	'ui.image_converter.copy_output': 'Veri URL’sini kopyala',
 	'ui.image_converter.download': 'İndir',
 	'ui.image_converter.output_placeholder': 'Dönüştürülen çıktı burada görünür...',
+	'tool.image-to-base64.display_name': 'Görselden Base64’e',
+	'tool.image-to-base64.tagline':
+		'Görselleri ham Base64 veya yapıştırmaya hazır veri URI dizelerine dönüştür',
+	'tool.image-to-base64.description':
+		'PNG, JPEG, WebP, GIF, BMP, AVIF, SVG ve ICO görsellerini tarayıcıda Base64 veya tam veri URI çıktısına çevir. Karakter uzunluklarını gör, sonucu kopyala ve .txt olarak indir; hiçbir dosya yüklenmez.',
+	'tool.image-to-base64.primary_keyword': 'görselden base64',
+	'tool.image-to-base64.meta_title': 'Görselden Base64’e — Veri URI Dönüştürücü | fmtly.dev',
+	'tool.image-to-base64.meta_description':
+		'Görselleri tarayıcıda Base64 veya veri URI çıktısına dönüştür. Kopyala, indir, karakter boyutunu gör ve büyük dosyalarda Web Worker ile akıcı kal.',
+	'tool.image-to-base64.operation': 'Görseli Base64’e dönüştür',
+	'tool.image-to-base64.faq.0.question': 'Görselim tarayıcıdan çıkıyor mu?',
+	'tool.image-to-base64.faq.0.answer':
+		'Hayır. Kodlama tamamen tarayıcıda yerel çalışır; dosya hiçbir sunucuya gönderilmez.',
+	'tool.image-to-base64.faq.1.question': 'Ham Base64 ile veri URI arasındaki fark nedir?',
+	'tool.image-to-base64.faq.1.answer':
+		'Ham Base64 yalnızca kodlanmış içeriği içerir. Veri URI ise `data:image/...;base64,` önekiyle MIME türünü de ekler; HTML, CSS ve JSON içine doğrudan gömülmeye hazırdır.',
+	'tool.image-to-base64.faq.2.question': 'Hangi görsel formatları destekleniyor?',
+	'tool.image-to-base64.faq.2.answer':
+		'PNG, JPEG, WebP, GIF, BMP, AVIF, SVG ve ICO girişleri desteklenir. Çıktı aynı görselin Base64/veri URI temsilidir.',
+	'tool.image-to-base64.faq.3.question': 'Büyük görseller nasıl işleniyor?',
+	'tool.image-to-base64.faq.3.answer':
+		'500KB üzerindeki girişler Web Worker içinde işlenir; kodlama sırasında arayüz akıcı kalır.',
+	'tool.image-to-base64.use_case.0': 'Küçük varlıkları HTML, CSS veya JSON içine satır içi gömmek',
+	'tool.image-to-base64.use_case.1':
+		'Veri URI gerektiren e-posta şablonları ve prototipler hazırlamak',
+	'tool.image-to-base64.use_case.2': 'API veya build araçları için Base64 örnek payload üretmek',
+	'tool.image-to-base64.use_case.3': 'Yükleme yapmadan görseli özel şekilde Base64’e çevirmek',
+	'tool.image-from-base64.display_name': 'Base64’ten Görsele',
+	'tool.image-from-base64.tagline':
+		'Base64 veya veri URI girdilerini indirilebilir görsel önizlemesine dönüştür',
+	'tool.image-from-base64.description':
+		'Ham Base64 dizelerini veya tam veri URI’leri yapıştırıp tarayıcıda görsel olarak çöz. MIME türünü algıla, boşlukları ve eksik dolguyu düzelt, sonucu önizle ve anında indir.',
+	'tool.image-from-base64.primary_keyword': 'base64ten görsele',
+	'tool.image-from-base64.meta_title': 'Base64’ten Görsele — Veri URI Çözücü | fmtly.dev',
+	'tool.image-from-base64.meta_description':
+		'Base64 veya veri URI metnini tarayıcıda görsele dönüştür. MIME türünü algılar, önizleme sunar, indirir ve büyük girdileri Web Worker ile çözer.',
+	'tool.image-from-base64.operation': 'Base64 görselini çöz',
+	'tool.image-from-base64.faq.0.question': 'Ham Base64 yerine tam veri URI yapıştırabilir miyim?',
+	'tool.image-from-base64.faq.0.answer':
+		'Evet. Araç hem ham Base64 metnini hem de `data:image/...;base64,...` biçimindeki tam veri URI girişlerini kabul eder.',
+	'tool.image-from-base64.faq.1.question': 'MIME türü eksikse ne olur?',
+	'tool.image-from-base64.faq.1.answer':
+		'Araç önce bayt imzalarından türü algılamaya çalışır. Algılayamazsa seçtiğin yedek çıktı türünü kullanır.',
+	'tool.image-from-base64.faq.2.question':
+		'Boşlukları veya eksik padding karakterlerini düzeltiyor mu?',
+	'tool.image-from-base64.faq.2.answer':
+		'Evet. Uygun durumlarda boşlukları kaldırır ve eksik padding karakterlerini tamamlar; yapılan düzeltmeler arayüzde gösterilir.',
+	'tool.image-from-base64.faq.3.question': 'Base64 girdim gizli kalır mı?',
+	'tool.image-from-base64.faq.3.answer':
+		'Evet. Tüm çözme işlemleri tarayıcıda yerel yapılır; içerik hiçbir yere yüklenmez.',
+	'tool.image-from-base64.use_case.0':
+		'API yanıtlarından veya veritabanı kayıtlarından görselleri geri almak',
+	'tool.image-from-base64.use_case.1':
+		'Veri URI dizelerini tasarım araçlarına veya dosyalara geri dönüştürmek',
+	'tool.image-from-base64.use_case.2':
+		'MIME bilgisi eksik Base64 payload’ları doğrulamak ve önizlemek',
+	'tool.image-from-base64.use_case.3':
+		'Bozuk boşluk/padding içeren Base64 girişlerini düzeltip indirmek',
+	'ui.image_to_base64.upload': 'Görsel yükle',
+	'ui.image_to_base64.clear': 'Temizle',
+	'ui.image_to_base64.no_file': 'Görsel seçilmedi',
+	'ui.image_to_base64.source_status': '{size} · {format}',
+	'ui.image_to_base64.output_status':
+		'{base64Chars} Base64 karakteri · {dataUrlChars} veri URI karakteri',
+	'ui.image_to_base64.worker_active':
+		'Büyük görsel algılandı (>{size}). Dönüşüm Web Worker içinde çalışır.',
+	'ui.image_to_base64.worker_used': 'Arka iş parçacığında işlendi',
+	'ui.image_to_base64.worker_failed':
+		'Worker kodlaması başarısız oldu. Ana iş parçacığına dönülüyor.',
+	'ui.image_to_base64.file_read_error': 'Görsel dosyası yüklenemedi',
+	'ui.image_to_base64.file_loaded': '{name} yüklendi',
+	'ui.image_to_base64.input_cleared': 'Görsel girdisi temizlendi',
+	'ui.image_to_base64.copy_empty': 'Kopyalanacak bir şey yok',
+	'ui.image_to_base64.copy_success': 'Çıktı kopyalandı',
+	'ui.image_to_base64.copy_data_uri_success': 'Veri URI kopyalandı',
+	'ui.image_to_base64.copy_error': 'Kopyalama başarısız',
+	'ui.image_to_base64.download_empty': 'İndirilecek bir şey yok',
+	'ui.image_to_base64.download_success': '{filename} indirildi',
+	'ui.image_to_base64.download_error': 'İndirme başarısız',
+	'ui.image_to_base64.drop_title': 'Görseli buraya bırak',
+	'ui.image_to_base64.drop_hint':
+		'PNG, JPEG, WebP, GIF, SVG, BMP, AVIF ve ICO bu tarayıcıda kalır.',
+	'ui.image_to_base64.source_preview_alt': 'Kaynak görsel önizlemesi',
+	'ui.image_to_base64.privacy_note': 'Kodlama yereldir; görselin tarayıcıdan çıkmaz.',
+	'ui.image_to_base64.performance_note': 'Büyük girdiler {size} üzerinde Web Worker kullanır.',
+	'ui.image_to_base64.stat.file_size': 'Görsel boyutu',
+	'ui.image_to_base64.stat.file_size_helper': 'yalnızca tarayıcı girdisi',
+	'ui.image_to_base64.stat.base64_length': 'Base64 uzunluğu',
+	'ui.image_to_base64.stat.base64_length_helper': 'önek hariç karakterler',
+	'ui.image_to_base64.stat.expansion': 'Payload büyümesi',
+	'ui.image_to_base64.stat.expansion_helper': 'beklenen Base64 ek yükü',
+	'ui.image_to_base64.processing': 'Kodlanıyor...',
+	'ui.image_to_base64.copy_base64': 'Base64 kopyala',
+	'ui.image_to_base64.copy_data_uri': 'Veri URI kopyala',
+	'ui.image_to_base64.download_base64': '.txt indir',
+	'ui.image_to_base64.download_data_uri': 'Veri URI indir',
+	'ui.image_to_base64.base64_output': 'Base64 çıktısı',
+	'ui.image_to_base64.output_placeholder': 'Kodlanmış Base64 burada görünür...',
+	'ui.image_to_base64.data_uri_output': 'Veri URI çıktısı',
+	'ui.image_to_base64.data_uri_placeholder': 'Veri URI burada görünür...',
+	'ui.image_to_base64.unsupported_image': 'Desteklenmeyen görsel formatı',
+	'ui.image_to_base64.empty_image': 'Görsel dosyası boş',
+	'ui.image_to_base64.convert_failed': 'Görsel Base64’e dönüştürülemedi',
+	'ui.image_from_base64.input_status': '{size} · {characters} karakter',
+	'ui.image_from_base64.output_status': '{size} · {type}',
+	'ui.image_from_base64.worker_active':
+		'Büyük Base64 girdisi algılandı (>{size}). Çözme işlemi Web Worker içinde çalışır.',
+	'ui.image_from_base64.worker_used': 'Arka iş parçacığında işlendi',
+	'ui.image_from_base64.worker_failed':
+		'Worker çözmesi başarısız oldu. Ana iş parçacığına dönülüyor.',
+	'ui.image_from_base64.privacy_note':
+		'Çözülen görsel baytları tarayıcıda kalır; hiçbir şey yüklenmez.',
+	'ui.image_from_base64.performance_note':
+		'Büyük Base64 dizeleri {size} üzerinde Web Worker kullanır.',
+	'ui.image_from_base64.input_placeholder':
+		'Buraya bir Base64 dizesi veya tam veri URI yapıştır...',
+	'ui.image_from_base64.output_placeholder': 'Çözülen görsel önizlemesi burada görünür...',
+	'ui.image_from_base64.stat.output_type': 'Çıktı türü',
+	'ui.image_from_base64.stat.output_type_helper': 'Algılanan veya yedek MIME',
+	'ui.image_from_base64.stat.output_size': 'Çıktı boyutu',
+	'ui.image_from_base64.stat.output_size_helper': 'Çözülen ikili boyut',
+	'ui.image_from_base64.stat.flags': 'Normalizasyon',
+	'ui.image_from_base64.stat.flags_helper': 'Önek, boşluk ve padding',
+	'ui.image_from_base64.input_cleared': 'Base64 girdisi temizlendi',
+	'ui.image_from_base64.sample_loaded': 'Örnek Base64 yüklendi',
+	'ui.image_from_base64.copy_empty': 'Kopyalanacak bir şey yok',
+	'ui.image_from_base64.copy_data_url_success': 'Veri URL’si kopyalandı',
+	'ui.image_from_base64.copy_error': 'Kopyalama başarısız',
+	'ui.image_from_base64.copy_base64_success': 'Normalize edilmiş Base64 kopyalandı',
+	'ui.image_from_base64.download_empty': 'İndirilecek bir şey yok',
+	'ui.image_from_base64.download_success': '{filename} indirildi',
+	'ui.image_from_base64.download_error': 'İndirme başarısız',
+	'ui.image_from_base64.decode_failed': 'Base64 görsel çözülemedi',
+	'ui.image_from_base64.error.empty': 'Çözmek için bir Base64 dizesi yapıştır.',
+	'ui.image_from_base64.error.invalid_mime':
+		'Veri URI desteklenmeyen bir görsel MIME türü bildiriyor.',
+	'ui.image_from_base64.error.invalid_characters':
+		'Girdi geçerli olmayan Base64 karakterleri içeriyor.',
+	'ui.image_from_base64.error.invalid_padding':
+		'Padding karakterleri yalnızca Base64 girdisinin sonunda bulunmalıdır.',
+	'ui.image_from_base64.error.invalid_length': 'Base64 uzunluğu geçersiz; çözülemiyor.',
+	'ui.image_from_base64.flag.data_uri': 'Veri URI',
+	'ui.image_from_base64.flag.whitespace': 'Boşluklar kaldırıldı',
+	'ui.image_from_base64.flag.padding': 'Padding düzeltildi',
+	'ui.image_from_base64.flag.fallback': 'Yedek MIME',
+	'ui.image_from_base64.flag.clean': 'Düzeltme yok',
+	'ui.image_from_base64.sample': 'Örnek yükle',
+	'ui.image_from_base64.clear': 'Temizle',
+	'ui.image_from_base64.fallback_mime': 'Yedek çıktı türü',
+	'ui.image_from_base64.processing': 'Çözülüyor...',
+	'ui.image_from_base64.copy_base64': 'Base64 kopyala',
+	'ui.image_from_base64.copy_data_url': 'Veri URL’sini kopyala',
+	'ui.image_from_base64.download': 'İndir',
+	'ui.image_from_base64.output_preview_alt': 'Çözülen görsel önizlemesi',
 	'ui.image_resizer.drop_title': 'Görseli buraya bırak veya gözat',
 	'ui.image_resizer.drop_hint': 'Dosyaların bu tarayıcıda kalır — hiçbir şey sunucuya yüklenmez.',
 	'ui.image_resizer.browse': 'Dosya seç',

--- a/src/lib/registry/tools/image.tools.ts
+++ b/src/lib/registry/tools/image.tools.ts
@@ -2,7 +2,9 @@ import type { ToolDefinition } from '../types.js';
 
 const imageRelated = [
 	{ category: 'image', slug: 'resize' },
-	{ category: 'image', slug: 'convert' }
+	{ category: 'image', slug: 'convert' },
+	{ category: 'image', slug: 'to-base64' },
+	{ category: 'image', slug: 'from-base64' }
 ] as const;
 
 export const imageTools: ToolDefinition[] = [
@@ -79,5 +81,92 @@ export const imageTools: ToolDefinition[] = [
 			'tool.image-format-converter.use_case.3'
 		],
 		sampleInput: ''
+	},
+	{
+		id: 'image-to-base64',
+		category: 'image',
+		slug: 'to-base64',
+		displayName: 'tool.image-to-base64.display_name',
+		tagline: 'tool.image-to-base64.tagline',
+		description: 'tool.image-to-base64.description',
+		primaryKeyword: 'tool.image-to-base64.primary_keyword',
+		metaTitle: 'tool.image-to-base64.meta_title',
+		metaDescription: 'tool.image-to-base64.meta_description',
+		engine: 'image',
+		operation: 'tool.image-to-base64.operation',
+		layoutVariant: 'single-panel',
+		inputLanguage: 'image',
+		outputLanguage: 'txt',
+		hasTreeView: false,
+		relatedTools: [...imageRelated],
+		faqs: [
+			{
+				question: 'tool.image-to-base64.faq.0.question',
+				answer: 'tool.image-to-base64.faq.0.answer'
+			},
+			{
+				question: 'tool.image-to-base64.faq.1.question',
+				answer: 'tool.image-to-base64.faq.1.answer'
+			},
+			{
+				question: 'tool.image-to-base64.faq.2.question',
+				answer: 'tool.image-to-base64.faq.2.answer'
+			},
+			{
+				question: 'tool.image-to-base64.faq.3.question',
+				answer: 'tool.image-to-base64.faq.3.answer'
+			}
+		],
+		useCases: [
+			'tool.image-to-base64.use_case.0',
+			'tool.image-to-base64.use_case.1',
+			'tool.image-to-base64.use_case.2',
+			'tool.image-to-base64.use_case.3'
+		],
+		sampleInput: ''
+	},
+	{
+		id: 'image-from-base64',
+		category: 'image',
+		slug: 'from-base64',
+		displayName: 'tool.image-from-base64.display_name',
+		tagline: 'tool.image-from-base64.tagline',
+		description: 'tool.image-from-base64.description',
+		primaryKeyword: 'tool.image-from-base64.primary_keyword',
+		metaTitle: 'tool.image-from-base64.meta_title',
+		metaDescription: 'tool.image-from-base64.meta_description',
+		engine: 'image',
+		operation: 'tool.image-from-base64.operation',
+		layoutVariant: 'single-panel',
+		inputLanguage: 'txt',
+		outputLanguage: 'image',
+		hasTreeView: false,
+		relatedTools: [...imageRelated],
+		faqs: [
+			{
+				question: 'tool.image-from-base64.faq.0.question',
+				answer: 'tool.image-from-base64.faq.0.answer'
+			},
+			{
+				question: 'tool.image-from-base64.faq.1.question',
+				answer: 'tool.image-from-base64.faq.1.answer'
+			},
+			{
+				question: 'tool.image-from-base64.faq.2.question',
+				answer: 'tool.image-from-base64.faq.2.answer'
+			},
+			{
+				question: 'tool.image-from-base64.faq.3.question',
+				answer: 'tool.image-from-base64.faq.3.answer'
+			}
+		],
+		useCases: [
+			'tool.image-from-base64.use_case.0',
+			'tool.image-from-base64.use_case.1',
+			'tool.image-from-base64.use_case.2',
+			'tool.image-from-base64.use_case.3'
+		],
+		sampleInput:
+			'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a5WQAAAAASUVORK5CYII='
 	}
 ];

--- a/src/lib/workers/image-from-base64.worker.ts
+++ b/src/lib/workers/image-from-base64.worker.ts
@@ -1,0 +1,22 @@
+import {
+	type Base64ToImageOptions,
+	type Base64ToImageWorkerRequest,
+	type Base64ToImageWorkerResponse,
+	decodeBase64ToImage
+} from '$engines/image/index.js';
+
+self.onmessage = (event: MessageEvent<Base64ToImageWorkerRequest>): void => {
+	const { id, input, options } = event.data;
+
+	try {
+		const result = decodeBase64ToImage(input, options as Partial<Base64ToImageOptions>);
+		const response: Base64ToImageWorkerResponse = { id, result };
+		self.postMessage(response);
+	} catch (error: unknown) {
+		const response: Base64ToImageWorkerResponse = {
+			id,
+			error: error instanceof Error ? error.message : 'Base64 image decode failed'
+		};
+		self.postMessage(response);
+	}
+};

--- a/src/lib/workers/image-to-base64.worker.ts
+++ b/src/lib/workers/image-to-base64.worker.ts
@@ -1,0 +1,22 @@
+import {
+	type ImageToBase64Input,
+	type ImageToBase64WorkerRequest,
+	type ImageToBase64WorkerResponse,
+	encodeImageToBase64
+} from '$engines/image/index.js';
+
+self.onmessage = (event: MessageEvent<ImageToBase64WorkerRequest>): void => {
+	const { id, input } = event.data;
+
+	try {
+		const result = encodeImageToBase64(input as ImageToBase64Input);
+		const response: ImageToBase64WorkerResponse = { id, result };
+		self.postMessage(response);
+	} catch (error: unknown) {
+		const response: ImageToBase64WorkerResponse = {
+			id,
+			error: error instanceof Error ? error.message : 'Image to Base64 conversion failed'
+		};
+		self.postMessage(response);
+	}
+};

--- a/src/routes/[category]/[tool]/+page.svelte
+++ b/src/routes/[category]/[tool]/+page.svelte
@@ -75,7 +75,9 @@
 	import PromptTokenOptimizerPanel from "$components/panels/ai/PromptTokenOptimizerPanel.svelte";
 	import SystemPromptBuilderPanel from "$components/panels/ai/SystemPromptBuilderPanel.svelte";
 	import ImageFormatConverterPanel from "$components/panels/image/ImageFormatConverterPanel.svelte";
+import ImageFromBase64Panel from "$components/panels/image/ImageFromBase64Panel.svelte";
 	import ImageResizerPanel from "$components/panels/image/ImageResizerPanel.svelte";
+import ImageToBase64Panel from "$components/panels/image/ImageToBase64Panel.svelte";
 	import TreePanel from "$components/panels/shared/TreePanel.svelte";
 	import ShareModal from "$components/modals/ShareModal.svelte";
 	import { getToolsByCategory } from "$registry";
@@ -637,11 +639,15 @@
 	</div>
 {:else if data.tool.category === "text" && data.tool.slug === "diff"}
 	<TextDiffPanel toolSlug={data.tool.slug} workspaceTools={textWorkspaceTools} />
-{:else if data.tool.category === "image" && (data.tool.slug === "resize" || data.tool.slug === "convert")}
+{:else if data.tool.category === "image" && ["resize", "convert", "to-base64", "from-base64"].includes(data.tool.slug)}
 	{#if data.tool.slug === "resize"}
 		<ImageResizerPanel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
-	{:else}
+	{:else if data.tool.slug === "convert"}
 		<ImageFormatConverterPanel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
+	{:else if data.tool.slug === "to-base64"}
+		<ImageToBase64Panel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
+	{:else}
+		<ImageFromBase64Panel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
 	{/if}
 {:else if isDiffTool}
 	<ToolLayout tool={localizedTool}>

--- a/tests/unit/image/image-engine.test.ts
+++ b/tests/unit/image/image-engine.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import {
+	IMAGE_BASE64_WORKER_THRESHOLD_BYTES,
 	IMAGE_CONVERTER_DEFAULT_OPTIONS,
 	IMAGE_CONVERTER_WORKER_THRESHOLD_BYTES,
 	IMAGE_RESIZER_DEFAULT_OPTIONS,
 	IMAGE_RESIZER_WORKER_THRESHOLD_BYTES,
 	computeScaledDimensions,
+	decodeBase64ToImage,
+	encodeImageToBase64,
 	getImageConversionExtension,
 	normalizeImageConversionOptions,
+	shouldUseBase64ToImageWorker,
 	shouldUseImageConverterWorker,
-	shouldUseImageResizerWorker
+	shouldUseImageResizerWorker,
+	shouldUseImageToBase64Worker
 } from '../../../src/lib/engines/image/index.js';
 
 describe('image resizer worker threshold', () => {
@@ -85,5 +90,57 @@ describe('image format converter options', () => {
 		expect(getImageConversionExtension('image/webp')).toBe('webp');
 		expect(getImageConversionExtension('image/avif')).toBe('avif');
 		expect(getImageConversionExtension('image/gif')).toBe('gif');
+	});
+});
+
+describe('image base64 conversion', () => {
+	it('encodes image bytes into a Base64 string and data URI', () => {
+		const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+		const result = encodeImageToBase64({
+			buffer: bytes.buffer,
+			sourceName: 'pixel.png',
+			sourceType: 'image/png',
+			sourceSizeBytes: bytes.byteLength
+		});
+
+		expect(result.base64).toBe('iVBORw==');
+		expect(result.dataUrl).toBe('data:image/png;base64,iVBORw==');
+		expect(result.downloadFilenames.base64).toBe('pixel-base64.txt');
+		expect(result.downloadFilenames.dataUri).toBe('pixel-data-uri.txt');
+	});
+
+	it('decodes data URIs and detects the image MIME type', () => {
+		const result = decodeBase64ToImage('data:image/png;base64,iVBORw0KGgo=');
+
+		expect(result.mimeType).toBe('image/png');
+		expect(result.metrics.hadDataUriPrefix).toBe(true);
+		expect(result.downloadFilename).toBe('decoded-image.png');
+	});
+
+	it('normalizes whitespace and missing padding when decoding', () => {
+		const result = decodeBase64ToImage(' iVBORw0K Ggo ');
+
+		expect(result.metrics.whitespaceRemoved).toBe(true);
+		expect(result.metrics.paddingAdded).toBe(true);
+		expect(result.mimeType).toBe('image/png');
+	});
+
+	it('falls back to the selected MIME type when bytes are not recognizable', () => {
+		const result = decodeBase64ToImage('aGVsbG8=', { fallbackMimeType: 'image/webp' });
+
+		expect(result.mimeType).toBe('image/webp');
+		expect(result.metrics.usedFallbackMimeType).toBe(true);
+		expect(result.downloadFilename).toBe('decoded-image.webp');
+	});
+
+	it('uses worker thresholds above 500KB for both directions', () => {
+		expect(shouldUseImageToBase64Worker(IMAGE_BASE64_WORKER_THRESHOLD_BYTES)).toBe(false);
+		expect(shouldUseImageToBase64Worker(IMAGE_BASE64_WORKER_THRESHOLD_BYTES + 1)).toBe(true);
+		expect(shouldUseBase64ToImageWorker('a'.repeat(IMAGE_BASE64_WORKER_THRESHOLD_BYTES))).toBe(
+			false
+		);
+		expect(shouldUseBase64ToImageWorker('a'.repeat(IMAGE_BASE64_WORKER_THRESHOLD_BYTES + 1))).toBe(
+			true
+		);
 	});
 });

--- a/tests/unit/shared/registry.test.ts
+++ b/tests/unit/shared/registry.test.ts
@@ -86,6 +86,26 @@ describe('Tool Registry', () => {
 			expect(tool.operation).toBe('Resize image');
 		});
 
+		it('returns image/to-base64 correctly', () => {
+			const rawTool = getTool('image', 'to-base64');
+			expect(rawTool).toBeDefined();
+			expect(rawTool?.id).toBe('image-to-base64');
+			expect(rawTool?.layoutVariant).toBe('single-panel');
+
+			const tool = localizeToolDefinition(rawTool!, t);
+			expect(tool.operation).toBe('Convert image to Base64');
+		});
+
+		it('returns image/from-base64 correctly', () => {
+			const rawTool = getTool('image', 'from-base64');
+			expect(rawTool).toBeDefined();
+			expect(rawTool?.id).toBe('image-from-base64');
+			expect(rawTool?.layoutVariant).toBe('single-panel');
+
+			const tool = localizeToolDefinition(rawTool!, t);
+			expect(tool.operation).toBe('Decode Base64 image');
+		});
+
 		it('returns json/validator correctly', () => {
 			const tool = getTool('json', 'validator');
 			expect(tool).toBeDefined();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `image/to-base64` and `image/from-base64` as first-class image tools with dedicated Svelte panels, worker-aware browser-only engines, and route wiring
- localize tool metadata and UI copy for `en`, `de`, `es`, `fr`, `it`, and `tr`, and mark both roadmap items as done
- add targeted image engine and registry coverage for the new Base64 image workflows

## Type of change
- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [x] test
- [ ] chore

## Scope
- [ ] JSON
- [ ] YAML
- [ ] XML
- [ ] CSV
- [ ] TOML
- [ ] Text
- [ ] Encode/Decode
- [x] Shared UI
- [ ] Infrastructure / CI
- [x] Documentation

## Checklist
- [x] I read `CONTRIBUTING.md` and `.windsurfrules`
- [x] I tested locally with `pnpm test -- tests/unit/image/image-engine.test.ts tests/unit/shared/registry.test.ts tests/unit/shared/seo.test.ts`
- [x] I ran `pnpm check`
- [x] I ran `pnpm lint`
- [x] I ran `pnpm build`
- [x] I added/updated tests for changed behavior
- [x] I added/updated i18n keys for all locales (`en,tr,de,es,fr,it`) if UI text changed
- [x] I used dynamic `import()` for heavy processing libraries
- [x] I kept user data processing in-browser only
- [x] I linked the related issue (or explained why none is needed)

## Screenshots / Demo
- [image_base64_tools_demo.mp4](https://cursor.com/agents/bc-43c54b14-29ef-4489-997e-cea47d579d35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimage_base64_tools_demo.mp4)
- [image-to-base64-result](https://cursor.com/agents/bc-43c54b14-29ef-4489-997e-cea47d579d35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimage_to_base64_result.webp)
- [base64-to-image-result](https://cursor.com/agents/bc-43c54b14-29ef-4489-997e-cea47d579d35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbase64_to_image_result.webp)

## Related issue
- Closes #141
- Closes #142

## Notes for reviewers
- The new tools share the existing image workspace UX and switch to Web Workers for inputs above 500KB in both directions.
- `pnpm build` now passes after restoring the missing local `gifenc` install in the workspace environment; no repository dependency version changes were required.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43c54b14-29ef-4489-997e-cea47d579d35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43c54b14-29ef-4489-997e-cea47d579d35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

