### PR TITLE
fix(image): keep SEO section visible on image workspace tools

### DIFF
--- a/src/routes/[category]/[tool]/+page.svelte
+++ b/src/routes/[category]/[tool]/+page.svelte
@@ -642,17 +642,20 @@
 {:else if data.tool.category === "text" && data.tool.slug === "diff"}
 	<TextDiffPanel toolSlug={data.tool.slug} workspaceTools={textWorkspaceTools} />
 {:else if data.tool.category === "image" && ["resize", "convert", "svg-optimizer", "to-base64", "from-base64"].includes(data.tool.slug)}
-	{#if data.tool.slug === "resize"}
-		<ImageResizerPanel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
-	{:else if data.tool.slug === "svg-optimizer"}
-		<SvgOptimizerPanel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
-	{:else if data.tool.slug === "convert"}
-		<ImageFormatConverterPanel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
-	{:else if data.tool.slug === "to-base64"}
-		<ImageToBase64Panel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
-	{:else}
-		<ImageFromBase64Panel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
-	{/if}
+	<!-- Match ToolLayout height so h-full image panels do not consume the viewport and hide the SEO section below. -->
+	<div class="w-full min-h-0 overflow-hidden" style="height: calc(100vh - var(--header-height));">
+		{#if data.tool.slug === "resize"}
+			<ImageResizerPanel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
+		{:else if data.tool.slug === "svg-optimizer"}
+			<SvgOptimizerPanel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
+		{:else if data.tool.slug === "convert"}
+			<ImageFormatConverterPanel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
+		{:else if data.tool.slug === "to-base64"}
+			<ImageToBase64Panel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
+		{:else}
+			<ImageFromBase64Panel toolSlug={data.tool.slug} workspaceTools={imageWorkspaceTools} />
+		{/if}
+	</div>
 {:else if isDiffTool}
 	<ToolLayout tool={localizedTool}>
 		{#snippet workspaceTabs()}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Image tools (resizer, format converter, Base64 to image, etc.) render custom full-height panels outside `ToolLayout`. Those panels used `h-full` against an unconstrained parent, so they grew with the viewport and pushed the page-level description, use cases, and FAQ block below the fold—especially after switching workspace tabs. This wraps the image tool branch in the same fixed height as `ToolLayout` (`calc(100vh - var(--header-height))`) with `min-h-0` and `overflow-hidden` so the panel flex layout scrolls internally and the SEO section stays reachable.

## Type of change

- [x] fix

## Scope

- [x] Shared UI

## Checklist

- [x] I read `CONTRIBUTING.md` and `.windsurfrules`
- [ ] I tested locally with `pnpm test` (Node/pnpm not available in this agent environment)
- [ ] I ran `pnpm check`
- [ ] I ran `pnpm lint`
- [ ] I ran `pnpm build`
- [ ] I added/updated tests for changed behavior
- [ ] I added/updated i18n keys for all locales (`en,tr,de,es,fr,it`) if UI text changed
- [x] I used dynamic `import()` for heavy processing libraries (unchanged)
- [x] I kept user data processing in-browser only
- [ ] I linked the related issue (or explained why none is needed)

## Screenshots / Demo (if UI changed)

Layout-only change; verify by opening `/image/resize` (or localized path), switching tabs, and scrolling past the tool to confirm the description and FAQ block appears without needing to scroll through a full-viewport empty panel.

## Related issue

Closes #

## Notes for reviewers

Behavior now matches other tools that use `ToolLayout` with a bounded viewport height.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d8773b6-0fcc-427f-90cc-42e72afd0ce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d8773b6-0fcc-427f-90cc-42e72afd0ce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

